### PR TITLE
Fix/null result not match result number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ Please see [here](https://github.com/hrntsm/Tunny/releases) for the data release
 
 - Restore feature was made asynchronous.
 
+### Fixed
+
+- Optimization does not stop when the value of Objective is null.
+  - When the objective values is null, optimizer try to get another variable and resolve solution.
+  - If it is 10 trial to get objectives in 1 optimize loop, optimizer throw error.
 
 ## [0.1.1] -2022-04-17
 

--- a/Tunny/Solver/Optuna.cs
+++ b/Tunny/Solver/Optuna.cs
@@ -207,12 +207,4 @@ namespace Tunny.Solver
             });
         }
     }
-
-    public class ModelResult
-    {
-        public int Number { get; set; }
-        public string Draco { get; set; }
-        public Dictionary<string, double> Variables { get; set; }
-        public double[] Objectives { get; set; }
-    }
 }

--- a/Tunny/UI/OptimizationWindow.Designer.cs
+++ b/Tunny/UI/OptimizationWindow.Designer.cs
@@ -381,7 +381,6 @@ namespace Tunny.UI
         private System.Windows.Forms.TextBox restoreModelNumTextBox;
         private System.Windows.Forms.Label restoreModelLabel;
         private System.Windows.Forms.ProgressBar restoreProgressBar;
-        private System.ComponentModel.BackgroundWorker backgroundWorker1;
         private System.ComponentModel.BackgroundWorker restoreBackgroundWorker;
         private System.Windows.Forms.Button restoreStopButton;
     }

--- a/Tunny/UI/OptimizationWindow.cs
+++ b/Tunny/UI/OptimizationWindow.cs
@@ -133,7 +133,14 @@ namespace Tunny.UI
             OptimizeLoop.SamplerType = samplerComboBox.Text;
             OptimizeLoop.StudyName = studyNameTextBox.Text;
 
-            if (_component.GhInOut.GetObjectiveValues().Count > 1 && (samplerComboBox.Text == "CMA-ES" || samplerComboBox.Text == "Random"))
+            var objectiveValues = _component.GhInOut.GetObjectiveValues();
+            if (objectiveValues.Count == 0)
+            {
+                ghCanvas.EnableUI();
+                optimizeRunButton.Enabled = true;
+                return;
+            }
+            else if (objectiveValues.Count > 1 && (samplerComboBox.Text == "CMA-ES" || samplerComboBox.Text == "Random"))
             {
                 MessageBox.Show("This sampler does not support multiple objectives optimization.", "Tunny", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 ghCanvas.EnableUI();

--- a/Tunny/Util/GrasshopperInOut.cs
+++ b/Tunny/Util/GrasshopperInOut.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Windows.Forms;
 
 using Grasshopper.Kernel;
 using Grasshopper.Kernel.Data;
@@ -206,12 +207,26 @@ namespace Tunny.Util
 
             foreach (IGH_Param objective in _objectives)
             {
-                IGH_StructureEnumerator ghEnumerator = objective.VolatileData.AllData(true);
+                IGH_StructureEnumerator ghEnumerator = objective.VolatileData.AllData(false);
+                if (ghEnumerator.Count() > 1)
+                {
+                    TunnyMessageBox.Show(
+                        "Tunny doesn't handle list output.\n Separate each objective if you want multiple objectives",
+                        "Tunny",
+                        MessageBoxButtons.OK,
+                        MessageBoxIcon.Error
+                    );
+                    return new List<double>();
+                }
                 foreach (IGH_Goo goo in ghEnumerator)
                 {
                     if (goo is GH_Number num)
                     {
                         values.Add(num.Value);
+                    }
+                    else if (goo == null)
+                    {
+                        values.Add(double.NaN);
                     }
                 }
             }

--- a/Tunny/Util/ModelResult.cs
+++ b/Tunny/Util/ModelResult.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace Tunny.Util
+{
+    public class ModelResult
+    {
+        public int Number { get; set; }
+        public string Draco { get; set; }
+        public Dictionary<string, double> Variables { get; set; }
+        public double[] Objectives { get; set; }
+    }
+}


### PR DESCRIPTION
## Changes

- Optimization does not stop when the value of Objective is null.
  - When the objective values is null, optimizer try to get another variable and resolve solution.
  - If it is 10 trial to get objectives in 1 optimize loop, optimizer throw error.

## Related issue number

close #10 
