### PR TITLE
Fix/change studyname error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Please see [here](https://github.com/hrntsm/Tunny/releases) for the data release
 ### Fixed
 
 - The PythonInstaller window now has no text on the progress bar.
+- When more than one Study exists, another Study Name is set and RunOpt no longer causes a Solver Error.
 
 ## [0.4.0] -2022-07-09
 

--- a/Tunny/Solver/Optuna/Algorithm.cs
+++ b/Tunny/Solver/Optuna/Algorithm.cs
@@ -95,16 +95,16 @@ namespace Tunny.Solver.Optuna
         private bool CheckExistStudyParameter(int nObjective, dynamic optuna)
         {
             PyList studySummaries = optuna.get_all_study_summaries("sqlite:///" + Settings.Storage);
-            var directions = new Dictionary<string, int>();
+            var studySummaryDict = new Dictionary<string, int>();
 
             foreach (dynamic pyObj in studySummaries)
             {
-                directions.Add((string)pyObj.study_name, (int)pyObj.directions.__len__());
+                studySummaryDict.Add((string)pyObj.study_name, (int)pyObj.directions.__len__());
             }
 
-            return directions.ContainsKey(Settings.StudyName)
-                ? CheckDirections(nObjective, directions)
-                : directions.Count == 0;
+            return studySummaryDict.ContainsKey(Settings.StudyName)
+                ? CheckDirections(nObjective, studySummaryDict)
+                : studySummaryDict.Count != 0;
         }
 
         private bool CheckDirections(int nObjective, Dictionary<string, int> directions)

--- a/Tunny/Solver/Optuna/Optuna.cs
+++ b/Tunny/Solver/Optuna/Optuna.cs
@@ -87,8 +87,8 @@ namespace Tunny.Solver.Optuna
         {
             TunnyMessageBox.Show(
                 "Tunny runtime error:\n" +
-                "Please send below message (& gh file if possible) to Tunny support.\n\n" +
-                "If this error occurs, the Tunny solver will not work after this unless Rhino is restarted." +
+                "Please send below message (& gh file if possible) to Tunny support.\n" +
+                "If this error occurs, the Tunny solver will not work after this unless Rhino is restarted.\n\n" +
                 "\" " + e.Message + " \"", "Tunny",
                 MessageBoxButtons.OK, MessageBoxIcon.Error);
         }


### PR DESCRIPTION
## Fixed

- When more than one Study exists, another Study Name is set and RunOpt no longer causes a Solver Error.

## Related issue number

close #81 
