### PR TITLE
Feature/run-gc-after-trial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,10 @@ Please see [here](https://github.com/hrntsm/Tunny/releases) for the data release
 - Enable Text Bake in the FishMarket component.
 - Allows selection of NSGA-II crossover methods.
   - `Uniform`, `BLXAlpha`, `SPX`, `SBX`, `VSBX`, `UNDX`
-- ability to set Popsize on CMA-ES restart
+- Ability to set Popsize on CMA-ES restart
+- Run GC after trial when has geometry attribute or setting always run.
+  - **This change probably make optimize slower before**
+  - If you want to cut this setting, set the value of "GcAfterTrial" to 2 in Settings.json.
 
 ### Changed
 

--- a/Tunny/Settings/Optimize.cs
+++ b/Tunny/Settings/Optimize.cs
@@ -1,3 +1,5 @@
+using Tunny.Solver.Optuna;
+
 namespace Tunny.Settings
 {
     public class Optimize
@@ -7,5 +9,6 @@ namespace Tunny.Settings
         public bool LoadExistStudy { get; set; } = true;
         public int SelectSampler { get; set; }
         public double Timeout { get; set; }
+        public GcAfterTrial GcAfterTrial { get; set; } = GcAfterTrial.HasGeometry;
     }
 }

--- a/Tunny/Solver/EndState.cs
+++ b/Tunny/Solver/EndState.cs
@@ -1,0 +1,12 @@
+namespace Tunny.Solver
+{
+    public enum EndState
+    {
+        AllTrialCompleted,
+        Timeout,
+        StoppedByUser,
+        DirectionNumNotMatch,
+        UseExitStudyWithoutLoading,
+        Error
+    }
+}

--- a/Tunny/Solver/Optuna/Algorithm.cs
+++ b/Tunny/Solver/Optuna/Algorithm.cs
@@ -213,7 +213,23 @@ namespace Tunny.Solver.Optuna
                 catch
                 {
                 }
+                finally
+                {
+                    RunGC(result);
+                }
                 trialNum++;
+            }
+        }
+
+        private void RunGC(EvaluatedGHResult result)
+        {
+            GcAfterTrial gcAfterTrial = Settings.Optimize.GcAfterTrial;
+            if (gcAfterTrial == GcAfterTrial.Always ||
+                (result.GeometryJson.Count > 0 && gcAfterTrial == GcAfterTrial.HasGeometry)
+            )
+            {
+                dynamic gc = Py.Import("gc");
+                gc.collect();
             }
         }
 
@@ -312,13 +328,10 @@ namespace Tunny.Solver.Optuna
 
     }
 
-    public enum EndState
+    public enum GcAfterTrial
     {
-        AllTrialCompleted,
-        Timeout,
-        StoppedByUser,
-        DirectionNumNotMatch,
-        UseExitStudyWithoutLoading,
-        Error
+        Always,
+        HasGeometry,
+        NoExecute,
     }
 }


### PR DESCRIPTION
## Added
- Run GC after trial when has geometry attribute or setting always run.
  - **This change probably make optimize slower before**
  - If you want to cut this setting, set the value of "GcAfterTrial" to 2 in Settings.json.


## Related issue number

close #104
