### PR TITLE
Feature/omit params in pareto front

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 Please see [here](https://github.com/hrntsm/Tunny/releases) for the data released for each version.
 
+## [UNRELEASED] -20xx-xx-xx
+
+### Added
+
+### Changed
+
+- When there are more than 10 params, the value of "Omit_values" is used instead of "params" to improve the visibility of the ParetoFront plot.
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
 ## [0.5.0] -2022-09-03
 
 ### Added

--- a/Tunny/Solver/Optuna/Optuna.cs
+++ b/Tunny/Solver/Optuna/Optuna.cs
@@ -188,6 +188,12 @@ namespace Tunny.Solver.Optuna
                 "        for i, original_label in enumerate(fig.data[scatter_id]['text']):\n" +
                 "            json_label = json.loads(original_label.replace('<br>', '\\n'))\n" +
                 "            json_label['user_attrs'].pop('Geometry')\n" +
+                "            param_len = len(json_label['params'])\n" +
+                "            while len(json_label['params']) > 10:\n" +
+                "                keys = list(json_label['params'].keys())\n" +
+                "                json_label['params'].pop(keys.pop())\n" +
+                "            if param_len > 10:\n" +
+                "                json_label['params']['__Omit_values__'] = 'True'\n" +
                 "            new_texts.append(json.dumps(json_label, indent=2).replace('\\n', '<br>'))\n" +
                 "        fig.data[scatter_id]['text'] = new_texts\n" +
                 "    return fig\n"


### PR DESCRIPTION

## Changed

- When there are more than 10 params, the value of "Omit_values" is used instead of "params" to improve the visibility of the ParetoFront plot.


## Related issue number

close #108 
