### PR TITLE
Add check python library setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Please see [here](https://github.com/hrntsm/Tunny/releases) for the data release
   - Optimize result handling more smooth some case.
   - Previously, it used to read and handle python, which was sometimes slow, but now it calls SQLite directly from CS.
 - Only non-dominated trial plot in pareto front.
+- Boolean to skip the behavior of checking if the python library is installed in settings.
+  - For some reason, the installer may be launched every time even if it is installed, so it can be forcibly skipped in the settings.
 
 ### Changed
 

--- a/Tunny/Settings/TunnySettings.cs
+++ b/Tunny/Settings/TunnySettings.cs
@@ -11,6 +11,7 @@ namespace Tunny.Settings
         public Result Result { get; set; } = new Result();
         public string StudyName { get; set; } = "study1";
         public string StoragePath { get; set; } = "/Fish.db";
+        public bool CheckPythonLibraries { get; set; } = true;
 
         public void Serialize(string path)
         {

--- a/Tunny/UI/OptimizationWindow.cs
+++ b/Tunny/UI/OptimizationWindow.cs
@@ -33,7 +33,7 @@ namespace Tunny.UI
             InitializeUIValues();
 
             PythonInstaller.Path = _component.GhInOut.ComponentFolder;
-            if (!PythonInstaller.CheckPackagesIsInstalled())
+            if (_settings.CheckPythonLibraries && !PythonInstaller.CheckPackagesIsInstalled())
             {
                 var installer = new PythonInstallDialog()
                 {


### PR DESCRIPTION
## Added
- Boolean to skip the behavior of checking if the python library is installed in settings.
  - For some reason, the installer may be launched every time even if it is installed, so it can be forcibly skipped in the settings.
  
## Related issue number

close #125 
