### PR TITLE
Quotation marks around path for terminal command, few typo fixes

### DIFF
--- a/Tunny/UI/OptimizationWindow.Designer.cs
+++ b/Tunny/UI/OptimizationWindow.Designer.cs
@@ -233,7 +233,7 @@ namespace Tunny.UI
             this.nTrialText.Name = "nTrialText";
             this.nTrialText.Size = new System.Drawing.Size(142, 23);
             this.nTrialText.TabIndex = 3;
-            this.nTrialText.Text = "Number of trial";
+            this.nTrialText.Text = "Number of trials";
             // 
             // continueStudyCheckBox
             // 
@@ -1634,7 +1634,7 @@ namespace Tunny.UI
             this.clearResultButton.Name = "clearResultButton";
             this.clearResultButton.Size = new System.Drawing.Size(264, 42);
             this.clearResultButton.TabIndex = 5;
-            this.clearResultButton.Text = "Clear flie";
+            this.clearResultButton.Text = "Clear file";
             this.clearResultButton.UseVisualStyleBackColor = true;
             this.clearResultButton.Click += new System.EventHandler(this.ClearResultButton_Click);
             // 

--- a/Tunny/UI/OptimizeWindowTab/VisualizeTab.cs
+++ b/Tunny/UI/OptimizeWindowTab/VisualizeTab.cs
@@ -15,7 +15,7 @@ namespace Tunny.UI
         {
             var dashboard = new Process();
             dashboard.StartInfo.FileName = PythonInstaller.GetEmbeddedPythonPath() + @"\Scripts\optuna-dashboard.exe";
-            dashboard.StartInfo.Arguments = @"sqlite:///" + _settings.StoragePath;
+            dashboard.StartInfo.Arguments = @"sqlite:///" + $"\"{_settings.StoragePath}\"";
             dashboard.StartInfo.UseShellExecute = false;
             dashboard.StartInfo.WindowStyle = ProcessWindowStyle.Minimized;
             dashboard.Start();


### PR DESCRIPTION
## Added

Quotation marks around the storage path used in terminal command

## Fixed

Two typos

## Related issue number

#142 
