### PR TITLE
Feature/journal storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,13 @@ Please see [here](https://github.com/hrntsm/Tunny/releases) for the data release
 - Display of estimated remaining time during optimization run.
 - In-memory optimization mode.
   - Mode that works faster instead of saving optimization results during optimization.
+- Support Journal storage.
+  - Since saving to the sqlite storage format that had been used up to now sometimes resulted in errors during optimization, a different storage format was supported.
 
 ### Changed
+
+- Boolean to start only the first time, since the Python installer may start every time.
+  - If you want to install it again, you can do so by checking the checkbox from Misc in the Settings tab.
 
 
 ### Deprecated
@@ -27,6 +32,7 @@ Please see [here](https://github.com/hrntsm/Tunny/releases) for the data release
 ### Fixed
 
 - Enabled Optuna-Dashboard to work even if the filename contains spaces.
+- The problem of saving the results of optimization in progress, etc., which causes an error and fails to save the results, can now be avoided by using JournalStorage.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ Please see [here](https://github.com/hrntsm/Tunny/releases) for the data release
 
 ## [UNRELEASED] -20xx-xx-xx
 
-
 ### Added
 
 - Display of estimated remaining time during optimization run.
@@ -22,12 +21,9 @@ Please see [here](https://github.com/hrntsm/Tunny/releases) for the data release
 - Boolean to start only the first time, since the Python installer may start every time.
   - If you want to install it again, you can do so by checking the checkbox from Misc in the Settings tab.
 
-
 ### Deprecated
 
-
 ### Removed
-
 
 ### Fixed
 
@@ -35,8 +31,6 @@ Please see [here](https://github.com/hrntsm/Tunny/releases) for the data release
 - The problem of saving the results of optimization in progress, etc., which causes an error and fails to save the results, can now be avoided by using JournalStorage.
 
 ### Security
-
-
 
 ## [v0.6.0] -2022-12-23
 

--- a/Tunny/Settings/Storage.cs
+++ b/Tunny/Settings/Storage.cs
@@ -2,8 +2,8 @@
 {
     public class Storage
     {
-        public string Path { get; set; } = "/Fish.db";
-        public StorageType Type { get; set; } = StorageType.Sqlite;
+        public string Path { get; set; } = "/fish.log";
+        public StorageType Type { get; set; } = StorageType.Journal;
     }
 
     public enum StorageType

--- a/Tunny/Solver/Algorithm.cs
+++ b/Tunny/Solver/Algorithm.cs
@@ -58,7 +58,7 @@ namespace Tunny.Solver
                 dynamic sampler = SetSamplerSettings(samplerType, ref nTrials, optuna, HasConstraints);
                 dynamic storage = CreateNewStorage();
 
-                if (CheckExistStudyParameter(nObjective, optuna))
+                if (CheckExistStudyParameter(nObjective, optuna, storage))
                 {
                     dynamic study = CreateStudy(directions, sampler, storage);
                     SetStudyUserAttr(study, NicknameToAttr(Variables.Select(v => v.NickName)), NicknameToAttr(ObjNickName));
@@ -75,13 +75,13 @@ namespace Tunny.Solver
             switch (Settings.Storage.Type)
             {
                 case StorageType.InMemory:
-                    storage = new InMemoryStorage().CreateNewStorage();
+                    storage = new InMemoryStorage().CreateNewStorage(false, string.Empty);
                     break;
                 case StorageType.Sqlite:
-                    storage = new SqliteStorage().CreateNewStorage(Settings.Storage.Path);
+                    storage = new SqliteStorage().CreateNewStorage(false, Settings.Storage.Path);
                     break;
                 case StorageType.Journal:
-                    storage = new JournalStorage().CreateNewStorage(Settings.Storage.Path);
+                    storage = new JournalStorage().CreateNewStorage(false, Settings.Storage.Path);
                     break;
                 default:
                     throw new ArgumentException("Storage type is not defined.");
@@ -124,9 +124,9 @@ namespace Tunny.Solver
             return directions;
         }
 
-        private bool CheckExistStudyParameter(int nObjective, dynamic optuna)
+        private bool CheckExistStudyParameter(int nObjective, dynamic optuna, dynamic storage)
         {
-            PyList studySummaries = optuna.get_all_study_summaries("sqlite:///" + Settings.Storage.Path);
+            PyList studySummaries = optuna.get_all_study_summaries(storage);
             var studySummaryDict = new Dictionary<string, int>();
 
             foreach (dynamic pyObj in studySummaries)
@@ -277,7 +277,7 @@ namespace Tunny.Solver
         {
             dynamic optuna = Py.Import("optuna");
             string studyName = Settings.StudyName;
-            optuna.copy_study(from_study_name: studyName, to_study_name: studyName, from_storage: storage, to_storage: "sqlite:///" + Settings.Storage.Path);
+            optuna.copy_study(from_study_name: studyName, to_study_name: studyName, from_storage: storage, to_storage: new StorageHandler().CreateNewStorage(false, Settings.Storage.Path));
         }
 
         private static dynamic EnqueueTrial(dynamic study, Dictionary<string, FishEgg> enqueueItems)

--- a/Tunny/Solver/Optuna.cs
+++ b/Tunny/Solver/Optuna.cs
@@ -24,7 +24,7 @@ namespace Tunny.Solver
         private readonly bool _hasConstraint;
         private readonly TunnySettings _settings;
 
-        public Optuna(string componentFolder, TunnySettings settings, bool hasConstraint) : base()
+        public Optuna(string componentFolder, TunnySettings settings, bool hasConstraint)
         {
             _componentFolder = componentFolder;
             _settings = settings;

--- a/Tunny/Solver/Optuna.cs
+++ b/Tunny/Solver/Optuna.cs
@@ -17,20 +17,18 @@ using Tunny.Util;
 
 namespace Tunny.Solver
 {
-    public class Optuna
+    public class Optuna : PythonInit
     {
         public double[] XOpt { get; private set; }
         private readonly string _componentFolder;
         private readonly bool _hasConstraint;
         private readonly TunnySettings _settings;
 
-        public Optuna(string componentFolder, TunnySettings settings, bool hasConstraint)
+        public Optuna(string componentFolder, TunnySettings settings, bool hasConstraint) : base()
         {
             _componentFolder = componentFolder;
             _settings = settings;
             _hasConstraint = hasConstraint;
-            string envPath = PythonInstaller.GetEmbeddedPythonPath() + @"\python310.dll";
-            Environment.SetEnvironmentVariable("PYTHONNET_PYDLL", envPath, EnvironmentVariableTarget.Process);
         }
 
         public bool RunSolver(

--- a/Tunny/Solver/Visualize.cs
+++ b/Tunny/Solver/Visualize.cs
@@ -14,7 +14,7 @@ namespace Tunny.Solver
         private readonly TunnySettings _settings;
         private readonly bool _hasConstraint;
 
-        public Visualize(TunnySettings settings, bool hasConstraint) : base()
+        public Visualize(TunnySettings settings, bool hasConstraint)
         {
             _settings = settings;
             _hasConstraint = hasConstraint;

--- a/Tunny/Solver/Visualize.cs
+++ b/Tunny/Solver/Visualize.cs
@@ -3,24 +3,21 @@ using System.Windows.Forms;
 
 using Python.Runtime;
 
-using Tunny.Handler;
 using Tunny.Settings;
 using Tunny.UI;
 using Tunny.Util;
 
 namespace Tunny.Solver
 {
-    public class Visualize
+    public class Visualize : PythonInit
     {
         private readonly TunnySettings _settings;
         private readonly bool _hasConstraint;
 
-        public Visualize(TunnySettings settings, bool hasConstraint)
+        public Visualize(TunnySettings settings, bool hasConstraint) : base()
         {
             _settings = settings;
             _hasConstraint = hasConstraint;
-            string envPath = PythonInstaller.GetEmbeddedPythonPath() + @"\python310.dll";
-            Environment.SetEnvironmentVariable("PYTHONNET_PYDLL", envPath, EnvironmentVariableTarget.Process);
         }
 
         private static dynamic LoadStudy(dynamic optuna, string storage, string studyName)

--- a/Tunny/Storage/IStorage.cs
+++ b/Tunny/Storage/IStorage.cs
@@ -9,6 +9,6 @@ namespace Tunny.Storage
     public interface ICreateStorage
     {
         dynamic Storage { get; set; }
-        dynamic CreateNewStorage(string storagePath);
+        dynamic CreateNewStorage(bool useInnerPythonEngine, string storagePath);
     }
 }

--- a/Tunny/Storage/IStorage.cs
+++ b/Tunny/Storage/IStorage.cs
@@ -1,0 +1,14 @@
+namespace Tunny.Storage
+{
+    public interface IStorage : ICreateStorage
+    {
+        void DuplicateStudyInStorage(string fromStudyName, string toStudyName, string storagePath);
+        StudySummary[] GetStudySummaries(string storagePath);
+    }
+
+    public interface ICreateStorage
+    {
+        dynamic Storage { get; set; }
+        dynamic CreateNewStorage(string storagePath);
+    }
+}

--- a/Tunny/Storage/InMemoryStorage.cs
+++ b/Tunny/Storage/InMemoryStorage.cs
@@ -1,0 +1,28 @@
+using Python.Runtime;
+
+using Tunny.Util;
+
+namespace Tunny.Storage
+{
+    public class InMemoryStorage : PythonInit, ICreateStorage
+    {
+        public dynamic Storage { get; set; }
+
+        public InMemoryStorage() : base()
+        {
+        }
+
+        public dynamic CreateNewStorage(string storagePath = null)
+        {
+            PythonEngine.Initialize();
+            using (Py.GIL())
+            {
+                dynamic optuna = Py.Import("optuna");
+                Storage = optuna.storages.InMemoryStorage();
+            }
+            PythonEngine.Shutdown();
+
+            return Storage;
+        }
+    }
+}

--- a/Tunny/Storage/InMemoryStorage.cs
+++ b/Tunny/Storage/InMemoryStorage.cs
@@ -8,10 +8,6 @@ namespace Tunny.Storage
     {
         public dynamic Storage { get; set; }
 
-        public InMemoryStorage()
-        {
-        }
-
         public dynamic CreateNewStorage(bool useInnerPythonEngine, string storagePath)
         {
             if (useInnerPythonEngine)

--- a/Tunny/Storage/InMemoryStorage.cs
+++ b/Tunny/Storage/InMemoryStorage.cs
@@ -12,17 +12,29 @@ namespace Tunny.Storage
         {
         }
 
-        public dynamic CreateNewStorage(string storagePath = null)
+        public dynamic CreateNewStorage(bool useInnerPythonEngine, string storagePath)
         {
-            PythonEngine.Initialize();
-            using (Py.GIL())
+            if (useInnerPythonEngine)
             {
-                dynamic optuna = Py.Import("optuna");
-                Storage = optuna.storages.InMemoryStorage();
+                PythonEngine.Initialize();
+                using (Py.GIL())
+                {
+                    CreateStorageProcess();
+                }
+                PythonEngine.Shutdown();
             }
-            PythonEngine.Shutdown();
+            else
+            {
+                CreateStorageProcess();
+            }
 
             return Storage;
+        }
+
+        private void CreateStorageProcess()
+        {
+            dynamic optuna = Py.Import("optuna");
+            Storage = optuna.storages.InMemoryStorage();
         }
     }
 }

--- a/Tunny/Storage/InMemoryStorage.cs
+++ b/Tunny/Storage/InMemoryStorage.cs
@@ -8,7 +8,7 @@ namespace Tunny.Storage
     {
         public dynamic Storage { get; set; }
 
-        public InMemoryStorage() : base()
+        public InMemoryStorage()
         {
         }
 

--- a/Tunny/Storage/JournalStorage.cs
+++ b/Tunny/Storage/JournalStorage.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+using Newtonsoft.Json;
+
+using Python.Runtime;
+
+using Tunny.Util;
+
+namespace Tunny.Storage
+{
+    public class JournalStorage : PythonInit, IStorage
+    {
+        [JsonProperty("op_code")]
+        public int OpCode { get; set; }
+
+        [JsonProperty("worker_id")]
+        public string WorkerId { get; set; }
+
+        [JsonProperty("study_name")]
+        public string StudyName { get; set; }
+
+        [JsonProperty("study_id")]
+        public int? StudyId { get; set; }
+
+        [JsonProperty("trial_id")]
+        public int? TrialId { get; set; }
+
+        [JsonProperty("datetime_start")]
+        public DateTime? DatetimeStart { get; set; }
+
+        [JsonProperty("datetime_complete")]
+        public DateTime? DatetimeComplete { get; set; }
+
+        [JsonProperty("directions")]
+        public int[] Directions { get; set; }
+
+        [JsonProperty("system_attr")]
+        public Dictionary<string, string[]> SystemAttr { get; set; }
+
+        [JsonProperty("user_attr")]
+        public Dictionary<string, object> UserAttr { get; set; }
+
+        [JsonProperty("param_name")]
+        public string ParamName { get; set; }
+
+        [JsonProperty("param_value_internal")]
+        public double? ParamValueInternal { get; set; }
+
+        [JsonProperty("distribution")]
+        public string Distribution { get; set; }
+
+        [JsonProperty("state")]
+        public int? State { get; set; }
+
+        [JsonProperty("values")]
+        public double?[] Values { get; set; }
+
+        [JsonIgnore]
+        public dynamic Storage { get; set; }
+
+        public JournalStorage() : base()
+        {
+        }
+
+        public static JournalStorage Deserialize(string json)
+        {
+            return JsonConvert.DeserializeObject<JournalStorage>(json);
+        }
+
+        public static JournalStorage[] Deserialize(List<string> json)
+        {
+            return Deserialize(json.ToArray());
+        }
+
+        public static JournalStorage[] Deserialize(string[] json)
+        {
+            var journalStorage = new JournalStorage[json.Length];
+            for (int i = 0; i < json.Length; i++)
+            {
+                journalStorage[i] = JsonConvert.DeserializeObject<JournalStorage>(json[i]);
+            }
+
+            return journalStorage;
+        }
+
+        public StudySummary[] GetStudySummaries(string storagePath)
+        {
+            var journalStorage = new List<string>();
+            foreach (string line in File.ReadLines(storagePath))
+            {
+                journalStorage.Add(line);
+            }
+            JournalStorage[] res = Deserialize(journalStorage);
+            var studyName = res.Where(x => x.OpCode == 0).Select(x => x.StudyName).Distinct().ToList();
+            IEnumerable<IGrouping<int?, JournalStorage>> userAttr = res.Where(x => x.OpCode == 2)
+                .GroupBy(x => x.StudyId);
+            var studySummaries = new StudySummary[studyName.Count];
+
+            int i = 0;
+            foreach (IGrouping<int?, JournalStorage> group in userAttr)
+            {
+                var studySummary = new StudySummary
+                {
+                    StudyId = group.Key.Value,
+                    StudyName = studyName[i],
+                    UserAttributes = new Dictionary<string, string[]>(),
+                    SystemAttributes = new Dictionary<string, string[]>(),
+                    Trials = new List<Trial>()
+                };
+                foreach (JournalStorage j in group)
+                {
+                    foreach (KeyValuePair<string, object> item in j.UserAttr)
+                    {
+                        if (item.Value is string str)
+                        {
+                            studySummary.UserAttributes.Add(item.Key, str.Split(','));
+                        }
+                        else if (item.Value is string[] strArray)
+                        {
+                            studySummary.UserAttributes.Add(item.Key, strArray);
+                        }
+                    }
+                }
+                studySummaries[i++] = studySummary;
+            }
+
+            return studySummaries;
+        }
+
+        public dynamic CreateNewStorage(string storagePath)
+        {
+            PythonEngine.Initialize();
+            using (Py.GIL())
+            {
+                dynamic optuna = Py.Import("optuna");
+                string filePath = storagePath;
+                dynamic lockObj = optuna.storages.JournalFileOpenLock(filePath);
+                Storage = optuna.storages.JournalStorage(optuna.storages.JournalFileStorage(filePath, lock_obj: lockObj));
+            }
+            PythonEngine.Shutdown();
+
+            return Storage;
+        }
+
+        public void DuplicateStudyInStorage(string fromStudyName, string toStudyName, string storagePath)
+        {
+            string storage = "sqlite:///" + storagePath;
+            PythonEngine.Initialize();
+            using (Py.GIL())
+            {
+                dynamic optuna = Py.Import("optuna");
+                optuna.copy_study(from_study_name: fromStudyName, to_study_name: toStudyName, from_storage: storage, to_storage: storage);
+            }
+            PythonEngine.Shutdown();
+        }
+    }
+}

--- a/Tunny/Storage/JournalStorage.cs
+++ b/Tunny/Storage/JournalStorage.cs
@@ -92,17 +92,24 @@ namespace Tunny.Storage
             {
                 return Array.Empty<StudySummary>();
             }
-            var journalStorage = new List<string>();
+            var journalStorageString = new List<string>();
             foreach (string line in File.ReadLines(storagePath))
             {
-                journalStorage.Add(line);
+                journalStorageString.Add(line);
             }
-            JournalStorage[] res = Deserialize(journalStorage);
-            var studyName = res.Where(x => x.OpCode == 0).Select(x => x.StudyName).Distinct().ToList();
-            IEnumerable<IGrouping<int?, JournalStorage>> userAttr = res.Where(x => x.OpCode == 2)
+            JournalStorage[] storage = Deserialize(journalStorageString);
+            var studyName = storage.Where(x => x.OpCode == 0).Select(x => x.StudyName).Distinct().ToList();
+            IEnumerable<IGrouping<int?, JournalStorage>> userAttr = storage.Where(x => x.OpCode == 2)
                 .GroupBy(x => x.StudyId);
             var studySummaries = new StudySummary[studyName.Count];
 
+            SetStudySummaries(studyName, userAttr, studySummaries);
+
+            return studySummaries;
+        }
+
+        private static void SetStudySummaries(List<string> studyName, IEnumerable<IGrouping<int?, JournalStorage>> userAttr, StudySummary[] studySummaries)
+        {
             int i = 0;
             foreach (IGrouping<int?, JournalStorage> group in userAttr)
             {
@@ -117,8 +124,6 @@ namespace Tunny.Storage
                 SetStudySummaryValue(group, studySummary);
                 studySummaries[i++] = studySummary;
             }
-
-            return studySummaries;
         }
 
         private static void SetStudySummaryValue(IGrouping<int?, JournalStorage> group, StudySummary studySummary)

--- a/Tunny/Storage/JournalStorage.cs
+++ b/Tunny/Storage/JournalStorage.cs
@@ -61,10 +61,6 @@ namespace Tunny.Storage
         [JsonIgnore]
         public dynamic Storage { get; set; }
 
-        public JournalStorage()
-        {
-        }
-
         public static JournalStorage Deserialize(string json)
         {
             return JsonConvert.DeserializeObject<JournalStorage>(json);

--- a/Tunny/Storage/JournalStorage.cs
+++ b/Tunny/Storage/JournalStorage.cs
@@ -88,6 +88,10 @@ namespace Tunny.Storage
 
         public StudySummary[] GetStudySummaries(string storagePath)
         {
+            if (File.Exists(storagePath) == false)
+            {
+                return Array.Empty<StudySummary>();
+            }
             var journalStorage = new List<string>();
             foreach (string line in File.ReadLines(storagePath))
             {

--- a/Tunny/Storage/JournalStorage.cs
+++ b/Tunny/Storage/JournalStorage.cs
@@ -61,7 +61,7 @@ namespace Tunny.Storage
         [JsonIgnore]
         public dynamic Storage { get; set; }
 
-        public JournalStorage() : base()
+        public JournalStorage()
         {
         }
 
@@ -114,39 +114,39 @@ namespace Tunny.Storage
                     SystemAttributes = new Dictionary<string, string[]>(),
                     Trials = new List<Trial>()
                 };
-                foreach (JournalStorage j in group)
-                {
-                    foreach (KeyValuePair<string, object> item in j.UserAttr)
-                    {
-                        if (item.Value is string str)
-                        {
-                            string[] values = str.Split(',');
-                            if (studySummary.UserAttributes.TryGetValue(item.Key, out string[] value))
-                            {
-                                _ = value.Union(values);
-                            }
-                            else
-                            {
-                                studySummary.UserAttributes.Add(item.Key, values);
-                            }
-                        }
-                        else if (item.Value is string[] strArray)
-                        {
-                            if (studySummary.UserAttributes.TryGetValue(item.Key, out string[] value))
-                            {
-                                _ = value.Union(strArray);
-                            }
-                            else
-                            {
-                                studySummary.UserAttributes.Add(item.Key, strArray);
-                            }
-                        }
-                    }
-                }
+                SetStudySummaryValue(group, studySummary);
                 studySummaries[i++] = studySummary;
             }
 
             return studySummaries;
+        }
+
+        private static void SetStudySummaryValue(IGrouping<int?, JournalStorage> group, StudySummary studySummary)
+        {
+            foreach (JournalStorage journal in group)
+            {
+                foreach (KeyValuePair<string, object> item in journal.UserAttr)
+                {
+                    string[] values = Array.Empty<string>();
+                    if (item.Value is string str)
+                    {
+                        values = str.Split(',');
+                    }
+                    else if (item.Value is string[] strArray)
+                    {
+                        values = strArray;
+                    }
+
+                    if (studySummary.UserAttributes.TryGetValue(item.Key, out string[] value))
+                    {
+                        _ = value.Union(values);
+                    }
+                    else
+                    {
+                        studySummary.UserAttributes.Add(item.Key, values);
+                    }
+                }
+            }
         }
 
         public dynamic CreateNewStorage(bool useInnerPythonEngine, string storagePath)

--- a/Tunny/Storage/SqliteStorage.cs
+++ b/Tunny/Storage/SqliteStorage.cs
@@ -1,4 +1,3 @@
-
 using System;
 using System.Collections.Generic;
 using System.Data.SQLite;
@@ -7,52 +6,16 @@ using System.IO;
 
 using Python.Runtime;
 
-using Tunny.Handler;
-using Tunny.Settings;
+using Tunny.Util;
 
-namespace Tunny.Solver
+namespace Tunny.Storage
 {
-    public class Study
+    public class SqliteStorage : PythonInit, IStorage
     {
-        private readonly string _componentFolder;
-        private readonly TunnySettings _settings;
+        public dynamic Storage { get; set; }
 
-        public Study(string componentFolder, TunnySettings settings)
+        public SqliteStorage() : base()
         {
-            _componentFolder = componentFolder;
-            _settings = settings;
-            string envPath = PythonInstaller.GetEmbeddedPythonPath() + @"\python310.dll";
-            Environment.SetEnvironmentVariable("PYTHONNET_PYDLL", envPath, EnvironmentVariableTarget.Process);
-        }
-
-        public StudySummary[] GetAllStudySummariesCS()
-        {
-            var studySummaries = new List<StudySummary>();
-            if (!File.Exists(_settings.Storage.Path))
-            {
-                return studySummaries.ToArray();
-            }
-
-            var sqliteConnection = new SQLiteConnectionStringBuilder
-            {
-                DataSource = _settings.Storage.Path,
-                Version = 3
-            };
-
-            using (var connection = new SQLiteConnection(sqliteConnection.ToString()))
-            {
-                connection.Open();
-
-                if (!CheckTableExist(connection))
-                {
-                    return studySummaries.ToArray();
-                }
-                GetStudy(studySummaries, connection);
-                GetStudyUserAttributes(studySummaries, connection);
-                // GetTrials(studySummaries, connection);
-            }
-
-            return studySummaries.ToArray();
         }
 
         private static bool CheckTableExist(SQLiteConnection connection)
@@ -148,10 +111,10 @@ namespace Tunny.Solver
             }
         }
 
-        public StudySummary[] GetAllStudySummariesPY()
+        public static StudySummary[] GetStudySummariesPY(string storagePath)
         {
             var studySummaries = new List<StudySummary>();
-            string storage = "sqlite:///" + _settings.Storage.Path;
+            string storage = "sqlite:///" + storagePath;
             PythonEngine.Initialize();
             using (Py.GIL())
             {
@@ -171,21 +134,23 @@ namespace Tunny.Solver
             return studySummaries.ToArray();
         }
 
-        public void CreateNewStorage()
+        public dynamic CreateNewStorage(string storagePath)
         {
-            string storage = "sqlite:///" + _settings.Storage.Path;
+            string sqlitePath = "sqlite:///" + storagePath;
             PythonEngine.Initialize();
             using (Py.GIL())
             {
                 dynamic optuna = Py.Import("optuna");
-                optuna.storages.RDBStorage(storage);
+                Storage = optuna.storages.RDBStorage(sqlitePath);
             }
             PythonEngine.Shutdown();
+
+            return Storage;
         }
 
-        public void Copy(string fromStudyName, string toStudyName)
+        public void DuplicateStudyInStorage(string fromStudyName, string toStudyName, string storagePath)
         {
-            string storage = "sqlite:///" + _settings.Storage.Path;
+            string storage = "sqlite:///" + storagePath;
             PythonEngine.Initialize();
             using (Py.GIL())
             {
@@ -195,33 +160,39 @@ namespace Tunny.Solver
             PythonEngine.Shutdown();
         }
 
-    }
+        public StudySummary[] GetStudySummaries(string storagePath)
+        {
+            var studySummaries = new List<StudySummary>();
+            if (!File.Exists(storagePath))
+            {
+                return studySummaries.ToArray();
+            }
 
-    public class StudySummary
-    {
-        public int StudyId { get; set; }
-        public string StudyName { get; set; }
-        public Dictionary<string, string[]> UserAttributes { get; set; }
-        public Dictionary<string, string[]> SystemAttributes { get; set; }
-        public int NTrials { get; set; }
-        public List<Trial> Trials { get; set; }
-    }
+            var sqliteConnection = new SQLiteConnectionStringBuilder
+            {
+                DataSource = storagePath,
+                Version = 3
+            };
 
-    public class Trial
-    {
-        public int TrialId { get; set; }
-        public int Number { get; set; }
-        public TrialState State { get; set; }
-        public DateTime DatetimeStart { get; set; }
-        public DateTime DatetimeComplete { get; set; }
-    }
+            using (var connection = new SQLiteConnection(sqliteConnection.ToString()))
+            {
+                connection.Open();
 
-    public enum TrialState
-    {
-        RUNNING,
-        WAITING,
-        COMPLETE,
-        PRUNED,
-        FAIL
+                if (!CheckTableExist(connection))
+                {
+                    return studySummaries.ToArray();
+                }
+                GetStudy(studySummaries, connection);
+                GetStudyUserAttributes(studySummaries, connection);
+                // GetTrials(studySummaries, connection);
+            }
+
+            return studySummaries.ToArray();
+        }
+
+        dynamic ICreateStorage.CreateNewStorage(string storagePath)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/Tunny/Storage/SqliteStorage.cs
+++ b/Tunny/Storage/SqliteStorage.cs
@@ -14,7 +14,7 @@ namespace Tunny.Storage
     {
         public dynamic Storage { get; set; }
 
-        public SqliteStorage() : base()
+        public SqliteStorage()
         {
         }
 
@@ -196,7 +196,6 @@ namespace Tunny.Storage
                 }
                 GetStudy(studySummaries, connection);
                 GetStudyUserAttributes(studySummaries, connection);
-                // GetTrials(studySummaries, connection);
             }
 
             return studySummaries.ToArray();

--- a/Tunny/Storage/SqliteStorage.cs
+++ b/Tunny/Storage/SqliteStorage.cs
@@ -14,10 +14,6 @@ namespace Tunny.Storage
     {
         public dynamic Storage { get; set; }
 
-        public SqliteStorage()
-        {
-        }
-
         private static bool CheckTableExist(SQLiteConnection connection)
         {
             int hasStudiesTable = 0;

--- a/Tunny/Storage/StorageHandler.cs
+++ b/Tunny/Storage/StorageHandler.cs
@@ -1,0 +1,71 @@
+using System;
+using System.IO;
+namespace Tunny.Storage
+{
+    public class StorageHandler : IStorage
+    {
+        public dynamic Storage { get; set; }
+
+        public dynamic CreateNewStorage(string storagePath = null)
+        {
+            ICreateStorage storage;
+
+            switch (Path.GetExtension(storagePath))
+            {
+                case null:
+                    storage = new InMemoryStorage();
+                    break;
+                case ".sqlite3":
+                case ".db":
+                    storage = new SqliteStorage();
+                    break;
+                case ".log":
+                    storage = new JournalStorage();
+                    break;
+                default:
+                    throw new ArgumentException("Storage type not supported");
+            }
+            Storage = storage.CreateNewStorage(storagePath);
+            return Storage;
+        }
+
+        public void DuplicateStudyInStorage(string fromStudyName, string toStudyName, string storagePath)
+        {
+            IStorage storage;
+
+            switch (Path.GetExtension(storagePath))
+            {
+                case ".sqlite3":
+                case ".db":
+                    storage = new SqliteStorage();
+                    break;
+                case ".log":
+                    storage = new JournalStorage();
+                    break;
+                default:
+                    throw new ArgumentException("Storage type not supported");
+            }
+            storage.DuplicateStudyInStorage(fromStudyName, toStudyName, storagePath);
+        }
+
+        public StudySummary[] GetStudySummaries(string storagePath)
+        {
+            IStorage storage;
+
+            switch (Path.GetExtension(storagePath))
+            {
+                case ".sqlite3":
+                case ".db":
+                    storage = new SqliteStorage();
+                    break;
+                case ".log":
+                    storage = new JournalStorage();
+                    break;
+                default:
+                    throw new ArgumentException("Storage type not supported");
+            }
+
+            return storage.GetStudySummaries(storagePath);
+        }
+    }
+}

--- a/Tunny/Storage/StorageHandler.cs
+++ b/Tunny/Storage/StorageHandler.cs
@@ -6,7 +6,7 @@ namespace Tunny.Storage
     {
         public dynamic Storage { get; set; }
 
-        public dynamic CreateNewStorage(string storagePath = null)
+        public dynamic CreateNewStorage(bool useInnerPythonEngine, string storagePath)
         {
             ICreateStorage storage;
 
@@ -25,7 +25,7 @@ namespace Tunny.Storage
                 default:
                     throw new ArgumentException("Storage type not supported");
             }
-            Storage = storage.CreateNewStorage(storagePath);
+            Storage = storage.CreateNewStorage(useInnerPythonEngine, storagePath);
             return Storage;
         }
 

--- a/Tunny/Storage/StudySummary.cs
+++ b/Tunny/Storage/StudySummary.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+
+namespace Tunny.Storage
+{
+    public class StudySummary
+    {
+        public int StudyId { get; set; }
+        public string StudyName { get; set; }
+        public Dictionary<string, string[]> UserAttributes { get; set; }
+        public Dictionary<string, string[]> SystemAttributes { get; set; }
+        public int NTrials { get; set; }
+        public List<Trial> Trials { get; set; }
+    }
+}

--- a/Tunny/Storage/Trial.cs
+++ b/Tunny/Storage/Trial.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Tunny.Storage
+{
+    public class Trial
+    {
+        public int TrialId { get; set; }
+        public int Number { get; set; }
+        public TrialState State { get; set; }
+        public DateTime DatetimeStart { get; set; }
+        public DateTime DatetimeComplete { get; set; }
+    }
+}

--- a/Tunny/Storage/TrialState.cs
+++ b/Tunny/Storage/TrialState.cs
@@ -1,0 +1,11 @@
+namespace Tunny.Storage
+{
+    public enum TrialState
+    {
+        RUNNING,
+        WAITING,
+        COMPLETE,
+        PRUNED,
+        FAIL
+    }
+}

--- a/Tunny/UI/OptimizationWindow.Designer.cs
+++ b/Tunny/UI/OptimizationWindow.Designer.cs
@@ -137,6 +137,7 @@ namespace Tunny.UI
             this.qmcScrambleCheckBox = new System.Windows.Forms.CheckBox();
             this.qmcWarnIndependentSamplingCheckBox = new System.Windows.Forms.CheckBox();
             this.tabPage1 = new System.Windows.Forms.TabPage();
+            this.checkPythonLibrariesCheckBox = new System.Windows.Forms.CheckBox();
             this.miscDefaultButton = new System.Windows.Forms.Button();
             this.comboBox1 = new System.Windows.Forms.ComboBox();
             this.runGarbageCollectionLabel = new System.Windows.Forms.Label();
@@ -1561,6 +1562,7 @@ namespace Tunny.UI
             // 
             // tabPage1
             // 
+            this.tabPage1.Controls.Add(this.checkPythonLibrariesCheckBox);
             this.tabPage1.Controls.Add(this.miscDefaultButton);
             this.tabPage1.Controls.Add(this.comboBox1);
             this.tabPage1.Controls.Add(this.runGarbageCollectionLabel);
@@ -1571,6 +1573,16 @@ namespace Tunny.UI
             this.tabPage1.TabIndex = 5;
             this.tabPage1.Text = "Misc";
             this.tabPage1.UseVisualStyleBackColor = true;
+            // 
+            // checkPythonLibrariesCheckBox
+            // 
+            this.checkPythonLibrariesCheckBox.AutoSize = true;
+            this.checkPythonLibrariesCheckBox.Location = new System.Drawing.Point(10, 69);
+            this.checkPythonLibrariesCheckBox.Name = "checkPythonLibrariesCheckBox";
+            this.checkPythonLibrariesCheckBox.Size = new System.Drawing.Size(377, 27);
+            this.checkPythonLibrariesCheckBox.TabIndex = 37;
+            this.checkPythonLibrariesCheckBox.Text = "Run Python installer at window startup";
+            this.checkPythonLibrariesCheckBox.UseVisualStyleBackColor = true;
             // 
             // miscDefaultButton
             // 
@@ -1877,6 +1889,7 @@ namespace Tunny.UI
         private System.Windows.Forms.CheckBox cmaEsWarmStartCmaEsCheckBox;
         private System.Windows.Forms.Label EstimatedTimeRemainingLabel;
         private System.Windows.Forms.CheckBox inMemoryCheckBox;
+        private System.Windows.Forms.CheckBox checkPythonLibrariesCheckBox;
     }
 }
 

--- a/Tunny/UI/OptimizationWindow.cs
+++ b/Tunny/UI/OptimizationWindow.cs
@@ -88,7 +88,7 @@ namespace Tunny.UI
             {
                 _settings = new TunnySettings
                 {
-                    Storage = new Storage
+                    Storage = new Settings.Storage
                     {
                         Path = _component.GhInOut.ComponentFolder + @"\Fish.db",
                     }

--- a/Tunny/UI/OptimizationWindow.cs
+++ b/Tunny/UI/OptimizationWindow.cs
@@ -153,7 +153,7 @@ namespace Tunny.UI
             _settings.Optimize.Timeout = (double)timeoutNumUpDown.Value;
             _settings.Optimize.ContinueStudy = continueStudyCheckBox.Checked;
             _settings.Optimize.CopyStudy = copyStudyCheckBox.Checked;
-            _settings.Storage.Type = inMemoryCheckBox.Checked ? StorageType.InMemory : StorageType.Sqlite;
+            _settings.Storage.Type = inMemoryCheckBox.Checked ? StorageType.InMemory : _settings.Storage.Type;
             _settings.StudyName = studyNameTextBox.Text;
             _settings.Result.OutputNumberString = outputModelNumTextBox.Text;
             _settings.Result.SelectVisualizeType = visualizeTypeComboBox.SelectedIndex;

--- a/Tunny/UI/OptimizationWindow.cs
+++ b/Tunny/UI/OptimizationWindow.cs
@@ -50,6 +50,8 @@ namespace Tunny.UI
                     StartPosition = FormStartPosition.CenterScreen
                 };
                 installer.Show(Owner);
+                _settings.CheckPythonLibraries = false;
+                checkPythonLibrariesCheckBox.Checked = false;
             }
         }
 
@@ -158,6 +160,7 @@ namespace Tunny.UI
             _settings.Result.OutputNumberString = outputModelNumTextBox.Text;
             _settings.Result.SelectVisualizeType = visualizeTypeComboBox.SelectedIndex;
             _settings.Result.NumberOfClusters = (int)visualizeClusterNumUpDown.Value;
+            _settings.CheckPythonLibraries = checkPythonLibrariesCheckBox.Checked;
             _settings.Optimize.Sampler = GetSamplerSettings();
         }
     }

--- a/Tunny/UI/OptimizeWindowTab/FileTab.cs
+++ b/Tunny/UI/OptimizeWindowTab/FileTab.cs
@@ -3,7 +3,8 @@ using System.Diagnostics;
 using System.IO;
 using System.Windows.Forms;
 
-using Tunny.Solver;
+using Tunny.Settings;
+using Tunny.Storage;
 
 namespace Tunny.UI
 {
@@ -33,22 +34,23 @@ namespace Tunny.UI
             var sfd = new SaveFileDialog
             {
                 FileName = Path.GetFileName(_settings.Storage.Path),
-                Filter = "SQLite database(*.db)|*.db",
+                Filter = "Journal Storage(*.log)|*.log|SQLite Storage(*.db,*.sqlite)|*.db,*.sqlite",
                 Title = "Set Tunny result file path",
 
             };
             if (sfd.ShowDialog() == DialogResult.OK)
             {
                 _settings.Storage.Path = sfd.FileName;
+                _settings.Storage.Type = Path.GetExtension(sfd.FileName) == ".log" ? StorageType.Journal : StorageType.Sqlite;
                 existingStudyComboBox.SelectedIndex = -1;
                 existingStudyComboBox.Items.Clear();
 
-                var study = new Study(_component.GhInOut.ComponentFolder, _settings);
-                if (!File.Exists(_settings.Storage.Path))
+                string storagePath = _settings.Storage.Path;
+                if (!File.Exists(storagePath))
                 {
-                    study.CreateNewStorage();
+                    new StorageHandler().CreateNewStorage(storagePath);
                 }
-                UpdateStudyComboBox(study);
+                UpdateStudyComboBox(storagePath);
             }
         }
     }

--- a/Tunny/UI/OptimizeWindowTab/FileTab.cs
+++ b/Tunny/UI/OptimizeWindowTab/FileTab.cs
@@ -49,7 +49,7 @@ namespace Tunny.UI
                 string storagePath = _settings.Storage.Path;
                 if (!File.Exists(storagePath))
                 {
-                    new StorageHandler().CreateNewStorage(storagePath);
+                    new StorageHandler().CreateNewStorage(true, storagePath);
                 }
                 UpdateStudyComboBox(storagePath);
             }

--- a/Tunny/UI/OptimizeWindowTab/FileTab.cs
+++ b/Tunny/UI/OptimizeWindowTab/FileTab.cs
@@ -34,14 +34,15 @@ namespace Tunny.UI
             var sfd = new SaveFileDialog
             {
                 FileName = Path.GetFileName(_settings.Storage.Path),
-                Filter = "Journal Storage(*.log)|*.log|SQLite Storage(*.db,*.sqlite)|*.db,*.sqlite",
+                Filter = "Journal Storage(*.log)|*.log|SQLite Storage(*.db,*.sqlite)|*.db;*.sqlite",
                 Title = "Set Tunny result file path",
 
             };
             if (sfd.ShowDialog() == DialogResult.OK)
             {
                 _settings.Storage.Path = sfd.FileName;
-                _settings.Storage.Type = Path.GetExtension(sfd.FileName) == ".log" ? StorageType.Journal : StorageType.Sqlite;
+                _settings.Storage.Type = Path.GetExtension(sfd.FileName) == ".log"
+                    ? StorageType.Journal : StorageType.Sqlite;
                 existingStudyComboBox.SelectedIndex = -1;
                 existingStudyComboBox.Items.Clear();
 

--- a/Tunny/UI/OptimizeWindowTab/OptimizeTab.cs
+++ b/Tunny/UI/OptimizeWindowTab/OptimizeTab.cs
@@ -8,7 +8,7 @@ using System.Windows.Forms;
 using Grasshopper.GUI;
 
 using Tunny.Handler;
-using Tunny.Solver;
+using Tunny.Storage;
 
 namespace Tunny.UI
 {
@@ -89,8 +89,7 @@ namespace Tunny.UI
             }
             else if (checkResult && copyStudyCheckBox.Enabled && copyStudyCheckBox.Checked)
             {
-                var study = new Study(_component.GhInOut.ComponentFolder, _settings);
-                study.Copy(existingStudyComboBox.Text, studyNameTextBox.Text);
+                new StorageHandler().DuplicateStudyInStorage(existingStudyComboBox.Text, studyNameTextBox.Text, _settings.Storage.Path);
                 _settings.StudyName = studyNameTextBox.Text;
             }
             else if (checkResult && continueStudyCheckBox.Checked)
@@ -183,18 +182,17 @@ namespace Tunny.UI
 
         private void UpdateStudyComboBox()
         {
-            var study = new Study(_component.GhInOut.ComponentFolder, _settings);
-            UpdateStudyComboBox(study);
+            UpdateStudyComboBox(_settings.Storage.Path);
         }
 
-        private void UpdateStudyComboBox(Study study)
+        private void UpdateStudyComboBox(string storagePath)
         {
             existingStudyComboBox.Items.Clear();
             visualizeTargetStudyComboBox.Items.Clear();
             outputTargetStudyComboBox.Items.Clear();
             cmaEsWarmStartComboBox.Items.Clear();
 
-            _summaries = study.GetAllStudySummariesCS();
+            _summaries = new StorageHandler().GetStudySummaries(storagePath);
 
             if (_summaries.Length > 0)
             {

--- a/Tunny/UI/OptimizeWindowTab/OptimizeTab.cs
+++ b/Tunny/UI/OptimizeWindowTab/OptimizeTab.cs
@@ -2,12 +2,14 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Windows.Forms;
 
 using Grasshopper.GUI;
 
 using Tunny.Handler;
+using Tunny.Settings;
 using Tunny.Storage;
 
 namespace Tunny.UI
@@ -25,10 +27,12 @@ namespace Tunny.UI
                 copyStudyCheckBox.Checked = false;
                 copyStudyCheckBox.Enabled = false;
                 studyNameTextBox.Enabled = true;
+                _settings.Storage.Type = StorageType.InMemory;
             }
             else
             {
                 continueStudyCheckBox.Enabled = true;
+                _settings.Storage.Type = Path.GetExtension(_settings.Storage.Path) == ".log" ? StorageType.Journal : StorageType.Sqlite;
             }
         }
 
@@ -39,12 +43,14 @@ namespace Tunny.UI
                 existingStudyComboBox.Enabled = true;
                 copyStudyCheckBox.Enabled = true;
                 studyNameTextBox.Enabled = copyStudyCheckBox.Checked;
+                inMemoryCheckBox.Enabled = false;
             }
-            else if (!continueStudyCheckBox.Checked)
+            else
             {
                 copyStudyCheckBox.Enabled = false;
                 existingStudyComboBox.Enabled = false;
                 studyNameTextBox.Enabled = true;
+                inMemoryCheckBox.Enabled = true;
             }
         }
 

--- a/Tunny/UI/OptimizeWindowTab/VisualizeTab.cs
+++ b/Tunny/UI/OptimizeWindowTab/VisualizeTab.cs
@@ -21,14 +21,7 @@ namespace Tunny.UI
                 return;
             }
 
-            Process[] dashboardProcess = Process.GetProcessesByName("optuna-dashboard");
-            if (dashboardProcess.Length > 0)
-            {
-                foreach (Process p in dashboardProcess)
-                {
-                    p.Kill();
-                }
-            }
+            CheckExistDashboardProcess();
             var dashboard = new Process();
             dashboard.StartInfo.FileName = PythonInstaller.GetEmbeddedPythonPath() + @"\Scripts\optuna-dashboard.exe";
             dashboard.StartInfo.Arguments = Path.GetExtension(_settings.Storage.Path) == ".log"
@@ -42,6 +35,18 @@ namespace Tunny.UI
             browser.StartInfo.FileName = @"http://127.0.0.1:8080/";
             browser.StartInfo.UseShellExecute = true;
             browser.Start();
+        }
+
+        private static void CheckExistDashboardProcess()
+        {
+            Process[] dashboardProcess = Process.GetProcessesByName("optuna-dashboard");
+            if (dashboardProcess.Length > 0)
+            {
+                foreach (Process p in dashboardProcess)
+                {
+                    p.Kill();
+                }
+            }
         }
 
         private void VisualizeTargetStudy_Changed(object sender, EventArgs e)

--- a/Tunny/UI/OptimizeWindowTab/VisualizeTab.cs
+++ b/Tunny/UI/OptimizeWindowTab/VisualizeTab.cs
@@ -1,6 +1,6 @@
-using System.IO;
 using System;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Windows.Forms;
 

--- a/Tunny/UI/OptimizeWindowTab/VisualizeTab.cs
+++ b/Tunny/UI/OptimizeWindowTab/VisualizeTab.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System;
 using System.Diagnostics;
 using System.Linq;
@@ -14,9 +15,25 @@ namespace Tunny.UI
     {
         private void DashboardButton_Click(object sender, EventArgs e)
         {
+            if (File.Exists(_settings.Storage.Path) == false)
+            {
+                TunnyMessageBox.Show("Please set exist result file path.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
+
+            Process[] dashboardProcess = Process.GetProcessesByName("optuna-dashboard");
+            if (dashboardProcess.Length > 0)
+            {
+                foreach (Process p in dashboardProcess)
+                {
+                    p.Kill();
+                }
+            }
             var dashboard = new Process();
             dashboard.StartInfo.FileName = PythonInstaller.GetEmbeddedPythonPath() + @"\Scripts\optuna-dashboard.exe";
-            dashboard.StartInfo.Arguments = @"sqlite:///" + $"\"{_settings.Storage.Path}\"";
+            dashboard.StartInfo.Arguments = Path.GetExtension(_settings.Storage.Path) == ".log"
+                ? $"\"{_settings.Storage.Path}\""
+                : @"sqlite:///" + $"\"{_settings.Storage.Path}\"";
             dashboard.StartInfo.UseShellExecute = false;
             dashboard.StartInfo.WindowStyle = ProcessWindowStyle.Minimized;
             dashboard.Start();

--- a/Tunny/UI/OptimizeWindowTab/VisualizeTab.cs
+++ b/Tunny/UI/OptimizeWindowTab/VisualizeTab.cs
@@ -5,6 +5,7 @@ using System.Windows.Forms;
 
 using Tunny.Handler;
 using Tunny.Solver;
+using Tunny.Storage;
 using Tunny.Util;
 
 namespace Tunny.UI

--- a/Tunny/Util/PythonInit.cs
+++ b/Tunny/Util/PythonInit.cs
@@ -6,7 +6,7 @@ namespace Tunny.Util
 {
     public abstract class PythonInit
     {
-        public PythonInit()
+        protected PythonInit()
         {
             string envPath = PythonInstaller.GetEmbeddedPythonPath() + @"\python310.dll";
             Environment.SetEnvironmentVariable("PYTHONNET_PYDLL", envPath, EnvironmentVariableTarget.Process);

--- a/Tunny/Util/PythonInit.cs
+++ b/Tunny/Util/PythonInit.cs
@@ -1,0 +1,15 @@
+using System;
+
+using Tunny.Handler;
+
+namespace Tunny.Util
+{
+    public abstract class PythonInit
+    {
+        public PythonInit()
+        {
+            string envPath = PythonInstaller.GetEmbeddedPythonPath() + @"\python310.dll";
+            Environment.SetEnvironmentVariable("PYTHONNET_PYDLL", envPath, EnvironmentVariableTarget.Process);
+        }
+    }
+}


### PR DESCRIPTION
## Added

- Support Journal storage.
  - Since saving to the sqlite storage format that had been used up to now sometimes resulted in errors during optimization, a different storage format was supported.
  
## Changed

- Boolean to start only the first time, since the Python installer may start every time.
  - If you want to install it again, you can do so by checking the checkbox from Misc in the Settings tab.
 
## Deprecated

## Removed

## Fixed

- The problem of saving the results of optimization in progress, etc., which causes an error and fails to save the results, can now be avoided by using JournalStorage.

## Security

## Related issue number

close #98 , #145 , #148 
