### PR TITLE
Featura/add reinstate button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ Please see [here](https://github.com/hrntsm/Tunny/releases) for the data release
 ### Changed
 
 - When outputting results from TunnyUI, even if the number of objective functions in Grasshopper does not match the number of objective functions in the result file, the results can still be output.
+- After optimization is finished, a window allows the user to choose whether to reinstate the results or not.
+- The words "reflect" and "restore" are changed to "reinstate" to match the Galapagos expression.
+- ModelNumber in the output section is changed to TrialNumber.
 
 ### Fixed
 
@@ -34,6 +37,7 @@ Please see [here](https://github.com/hrntsm/Tunny/releases) for the data release
 - Optuna-Dashboard doesn't work when artifact-dir contains space.
 - Fixed an error when there is no file in the path specified in FishPrintByPath.
 - Rhino crashes when reinstating a value to a slider if the categorical value is a number.
+- MessageBox is now not below the back of Grasshopper window.
 
 ## [v0.11.1] -2024-05-10
 

--- a/Tunny.Core/Handler/ProgressState.cs
+++ b/Tunny.Core/Handler/ProgressState.cs
@@ -14,5 +14,20 @@ namespace Tunny.Core.Handler
         public double HypervolumeRatio { get; set; }
         public TimeSpan EstimatedTimeRemaining { get; set; }
         public bool IsReportOnly { get; set; }
+
+        public ProgressState()
+        {
+        }
+
+        public ProgressState(IList<Parameter> parameters)
+        {
+            Parameter = parameters;
+        }
+
+        public ProgressState(IList<Parameter> parameters, bool isReportOnly)
+        {
+            Parameter = parameters;
+            IsReportOnly = isReportOnly;
+        }
     }
 }

--- a/Tunny.Core/TEnum/OutputMode.cs
+++ b/Tunny.Core/TEnum/OutputMode.cs
@@ -4,7 +4,7 @@ namespace Tunny.Core.TEnum
     {
         ParatoSolutions,
         AllTrials,
-        ModelNumber,
+        TrialNumber,
         ReflectToSliders
     }
 }

--- a/Tunny.Core/Util/TEnvVariables.cs
+++ b/Tunny.Core/Util/TEnvVariables.cs
@@ -14,6 +14,8 @@ namespace Tunny.Core.Util
         public static string PythonPath { get; } = Path.Combine(TunnyEnvPath, "python");
         public static string ComponentFolder { get; } = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
         public static Version OldStorageVersion { get; } = new Version("0.9.1");
+        public static IntPtr GrasshopperWindowHandle { get; set; }
+
         public static string TmpDirPath
         {
             get

--- a/Tunny.CoreTests/Handler/ProgressStateTests.cs
+++ b/Tunny.CoreTests/Handler/ProgressStateTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq.Expressions;
 
 using Xunit;
 
@@ -36,6 +37,20 @@ namespace Tunny.Core.Handler.Tests
             Assert.Equal(0, progressState.HypervolumeRatio);
             Assert.Equal(new System.TimeSpan(), progressState.EstimatedTimeRemaining);
             Assert.False(progressState.IsReportOnly);
+        }
+
+        [Fact]
+        public void ProgressStateConstructorTest()
+        {
+            var param = new List<Input.Parameter>();
+            var noArg = new ProgressState();
+            var oneArg = new ProgressState(param);
+            var twoArg = new ProgressState(param, true);
+
+            Assert.Equal(param, oneArg.Parameter);
+            Assert.Equal(0, noArg.TrialNumber);
+            Assert.Equal(0, noArg.ObjectiveNum);
+            Assert.True(twoArg.IsReportOnly);
         }
     }
 }

--- a/Tunny.CoreTests/Util/TEnvVariablesTests.cs
+++ b/Tunny.CoreTests/Util/TEnvVariablesTests.cs
@@ -12,5 +12,12 @@ namespace Tunny.Core.Util.Tests
             string path = TEnvVariables.TmpDirPath;
             Assert.True(Directory.Exists(path));
         }
+
+        [Fact]
+        public void GrasshopperHWNDTest()
+        {
+            TEnvVariables.GrasshopperWindowHandle = new System.IntPtr(123);
+            Assert.Equal(123, TEnvVariables.GrasshopperWindowHandle.ToInt32());
+        }
     }
 }

--- a/Tunny/Component/Operation/DeconstructFish.cs
+++ b/Tunny/Component/Operation/DeconstructFish.cs
@@ -51,7 +51,7 @@ namespace Tunny.Component.Operation
             foreach (GH_Fish fish in fishes)
             {
                 Fish value = fish.Value;
-                var path = new GH_Path(0, value.ModelNumber);
+                var path = new GH_Path(0, value.TrialNumber);
                 SetVariables(numberVariables, textVariables, value, path);
                 SetObjectives(objectives, value, path);
                 SetAttributes(attributes, value, path);

--- a/Tunny/Component/Optimizer/BoneFishComponent.cs
+++ b/Tunny/Component/Optimizer/BoneFishComponent.cs
@@ -124,8 +124,8 @@ namespace Tunny.Component.Optimizer
         private void OptimizeProgressChangedHandler(object sender, ProgressChangedEventArgs e)
         {
             _count++;
-            var pState = (ProgressState)e.UserState;
-            UpdateGrasshopper(pState.Parameter);
+            var progressState = (ProgressState)e.UserState;
+            UpdateGrasshopper(progressState);
             Message = $"Trial {_count}";
         }
 

--- a/Tunny/Component/Optimizer/OptimizerComponentBase.cs
+++ b/Tunny/Component/Optimizer/OptimizerComponentBase.cs
@@ -13,7 +13,7 @@ using Grasshopper.Kernel.Special;
 
 using Tunny.Component.Params;
 using Tunny.Component.Print;
-using Tunny.Core.Input;
+using Tunny.Core.Handler;
 using Tunny.Core.TEnum;
 using Tunny.Core.Util;
 using Tunny.Type;
@@ -85,11 +85,18 @@ namespace Tunny.Component.Optimizer
             GhInOut = new GrasshopperInOut(this);
         }
 
-        public void UpdateGrasshopper(IList<Parameter> parameters)
+        public void UpdateGrasshopper(ProgressState progressState)
         {
             TLog.MethodStart();
             GrasshopperStatus = GrasshopperStates.RequestProcessing;
-            GhInOut.NewSolution(parameters);
+            if (progressState.IsReportOnly)
+            {
+                GhInOut.NewSolution(progressState.Parameter);
+            }
+            else
+            {
+                ExpireSolution(true);
+            }
             GrasshopperStatus = GrasshopperStates.RequestProcessed;
         }
 

--- a/Tunny/Component/Optimizer/UIOptimizerComponentBase.cs
+++ b/Tunny/Component/Optimizer/UIOptimizerComponentBase.cs
@@ -7,6 +7,7 @@ using Grasshopper.GUI;
 using Grasshopper.GUI.Canvas;
 using Grasshopper.Kernel;
 
+using Tunny.Core.Util;
 using Tunny.UI;
 
 namespace Tunny.Component.Optimizer
@@ -33,6 +34,7 @@ namespace Tunny.Component.Optimizer
         private void ShowOptimizationWindow()
         {
             GH_DocumentEditor owner = Instances.DocumentEditor;
+            TEnvVariables.GrasshopperWindowHandle = owner.Handle;
 
             if (OptimizationWindow == null || OptimizationWindow.IsDisposed)
             {

--- a/Tunny/Component/Util/FishMarket.cs
+++ b/Tunny/Component/Util/FishMarket.cs
@@ -130,7 +130,7 @@ namespace Tunny.Component.Util
                 GeometryBase dupGeometry = geometry.Duplicate();
                 dupGeometry.Rotate(Vector3d.VectorAngle(Vector3d.XAxis, _settings.Plane.XAxis), Vector3d.ZAxis, modelMinPt);
                 dupGeometry.Translate(moveVec + new Vector3d(_settings.Plane.Origin) - new Vector3d(modelMinPt));
-                arrayedGeometries.Append(GooConverter.GeometryBaseToGoo(dupGeometry), new GH_Path(0, _fishes[index].Value.ModelNumber));
+                arrayedGeometries.Append(GooConverter.GeometryBaseToGoo(dupGeometry), new GH_Path(0, _fishes[index].Value.TrialNumber));
                 movedGeometries[i] = dupGeometry;
             }
             modelMinPt = GetUnionBoundingBoxMinPt(movedGeometries);

--- a/Tunny/Handler/OutputLoop.cs
+++ b/Tunny/Handler/OutputLoop.cs
@@ -79,7 +79,7 @@ namespace Tunny.Handler
             TLog.MethodStart();
             fishes.Add(new Fish
             {
-                ModelNumber = trial.Number,
+                TrialNumber = trial.Number,
                 Variables = SetVariables(trial.Params, varNickname),
                 Objectives = SetObjectives(trial.Values, objNickname),
                 Attributes = SetAttributes(ParseAttrs(trial.UserAttrs)),

--- a/Tunny/Solver/Algorithm.cs
+++ b/Tunny/Solver/Algorithm.cs
@@ -10,7 +10,6 @@ using Optuna.Study;
 
 using Python.Runtime;
 
-using Tunny.Component.Optimizer;
 using Tunny.Core.Handler;
 using Tunny.Core.Input;
 using Tunny.Core.Settings;

--- a/Tunny/Solver/Solver.cs
+++ b/Tunny/Solver/Solver.cs
@@ -48,9 +48,9 @@ namespace Tunny.Solver
                 var optimize = new Algorithm(variables, _hasConstraint, objectives, fishEggs, _settings, Eval);
                 optimize.Solve();
                 OptimalParameters = optimize.OptimalParameters;
-                EndMessage(optimize);
+                DialogResult dialogResult = EndMessage(optimize);
 
-                return true;
+                return dialogResult == DialogResult.Yes;
             }
             catch (Exception e)
             {
@@ -86,14 +86,16 @@ namespace Tunny.Solver
             }
         }
 
-        private static void EndMessage(Algorithm optimize)
+        private static DialogResult EndMessage(Algorithm optimize)
         {
             TLog.MethodStart();
+            DialogResult dialogResult = DialogResult.None;
             ToComponentEndMessage(optimize);
             if (OptimizeLoop.Component is UIOptimizeComponentBase)
             {
-                ShowUIEndMessages(optimize.EndState);
+                dialogResult = ShowUIEndMessages(optimize.EndState);
             }
+            return dialogResult;
         }
 
         private static void ToComponentEndMessage(Algorithm optimize)
@@ -131,36 +133,38 @@ namespace Tunny.Solver
             OptimizeLoop.Component.SetInfo(message);
         }
 
-        private static void ShowUIEndMessages(EndState endState)
+        private static DialogResult ShowUIEndMessages(EndState endState)
         {
             TLog.MethodStart();
+            DialogResult dialogResult;
             switch (endState)
             {
                 case EndState.Timeout:
-                    TunnyMessageBox.Show("Solver completed successfully.\n\nThe specified time has elapsed.", "Tunny");
+                    dialogResult = TunnyMessageBox.Show("Solver completed successfully.\n\nThe specified time has elapsed.\nReinstate the best trial to the slider?", "Tunny", MessageBoxButtons.YesNo);
                     break;
                 case EndState.AllTrialCompleted:
-                    TunnyMessageBox.Show("Solver completed successfully.\n\nThe specified number of trials has been completed.", "Tunny");
+                    dialogResult = TunnyMessageBox.Show("Solver completed successfully.\n\nThe specified number of trials has been completed.\nReinstate the best trial to the slider?", "Tunny", MessageBoxButtons.YesNo);
                     break;
                 case EndState.StoppedByUser:
-                    TunnyMessageBox.Show("Solver completed successfully.\n\nThe user stopped the solver.", "Tunny");
+                    dialogResult = TunnyMessageBox.Show("Solver completed successfully.\n\nThe user stopped the solver.", "Tunny", MessageBoxButtons.YesNo);
                     break;
                 case EndState.StoppedByOptuna:
-                    TunnyMessageBox.Show("Solver completed successfully.\n\nThe Optuna stopped the solver.", "Tunny");
+                    dialogResult = TunnyMessageBox.Show("Solver completed successfully.\n\nThe Optuna stopped the solver.", "Tunny", MessageBoxButtons.YesNo);
                     break;
                 case EndState.DirectionNumNotMatch:
-                    TunnyMessageBox.Show("Solver error.\n\nThe number of Objective in the existing Study does not match the one that you tried to run; Match the number of objective, or change the \"Study Name\".", "Tunny", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    dialogResult = TunnyMessageBox.Show("Solver error.\n\nThe number of Objective in the existing Study does not match the one that you tried to run; Match the number of objective, or change the \"Study Name\".", "Tunny", MessageBoxButtons.OK, MessageBoxIcon.Error);
                     break;
                 case EndState.UseExitStudyWithoutContinue:
-                    TunnyMessageBox.Show("Solver error.\n\n\"Load if study file exists\" was false even though the same \"Study Name\" exists. Please change the name or set it to true.", "Tunny", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    dialogResult = TunnyMessageBox.Show("Solver error.\n\n\"Load if study file exists\" was false even though the same \"Study Name\" exists. Please change the name or set it to true.", "Tunny", MessageBoxButtons.OK, MessageBoxIcon.Error);
                     break;
                 case EndState.Error:
-                    TunnyMessageBox.Show("Solver error.", "Tunny");
+                    dialogResult = TunnyMessageBox.Show("Solver error.", "Tunny");
                     break;
                 default:
-                    TunnyMessageBox.Show("Solver unexpected error.", "Tunny");
+                    dialogResult = TunnyMessageBox.Show("Solver unexpected error.", "Tunny");
                     break;
             }
+            return dialogResult;
         }
 
         private static void ShowErrorMessages(Exception e)

--- a/Tunny/Solver/Solver.cs
+++ b/Tunny/Solver/Solver.cs
@@ -144,13 +144,13 @@ namespace Tunny.Solver
             switch (endState)
             {
                 case EndState.Timeout:
-                    dialogResult = TunnyMessageBox.Show(CompleteMessagePrefix + "\n\nThe specified time has elapsed."+ reinstateMessage, "Tunny", button);
+                    dialogResult = TunnyMessageBox.Show(CompleteMessagePrefix + "\n\nThe specified time has elapsed." + reinstateMessage, "Tunny", button);
                     break;
                 case EndState.AllTrialCompleted:
                     dialogResult = TunnyMessageBox.Show(CompleteMessagePrefix + "\n\nThe specified number of trials has been completed." + reinstateMessage, "Tunny", button);
                     break;
                 case EndState.StoppedByUser:
-                    dialogResult = TunnyMessageBox.Show(CompleteMessagePrefix + "\n\nThe user stopped the solver."+ reinstateMessage, "Tunny", button);
+                    dialogResult = TunnyMessageBox.Show(CompleteMessagePrefix + "\n\nThe user stopped the solver." + reinstateMessage, "Tunny", button);
                     break;
                 case EndState.StoppedByOptuna:
                     dialogResult = TunnyMessageBox.Show(CompleteMessagePrefix + "\n\nThe Optuna stopped the solver." + reinstateMessage, "Tunny", button);

--- a/Tunny/Type/Fish.cs
+++ b/Tunny/Type/Fish.cs
@@ -17,7 +17,7 @@ namespace Tunny.Type
     [Serializable]
     public class Fish
     {
-        public int ModelNumber { get; set; }
+        public int TrialNumber { get; set; }
         public Dictionary<string, object> Variables { get; set; }
         public Dictionary<string, double> Objectives { get; set; }
         public Dictionary<string, object> Attributes { get; set; }
@@ -30,7 +30,7 @@ namespace Tunny.Type
         public Fish(Trial trial, string[] objectiveNames)
         {
             TLog.MethodStart();
-            ModelNumber = trial.Number;
+            TrialNumber = trial.Number;
             Variables = trial.Params;
             Attributes = trial.UserAttrs;
             Objectives = new Dictionary<string, double>();

--- a/Tunny/Type/GH_Fish.cs
+++ b/Tunny/Type/GH_Fish.cs
@@ -52,7 +52,7 @@ namespace Tunny.Type
         public override string ToString()
         {
             var sb = new StringBuilder();
-            SetModelNumber(sb);
+            SetTrialNumber(sb);
             SetVariables(sb);
             SetObjectives(sb);
             SetAttributes(sb);
@@ -117,10 +117,10 @@ namespace Tunny.Type
             }
         }
 
-        private void SetModelNumber(StringBuilder sb)
+        private void SetTrialNumber(StringBuilder sb)
         {
             sb.AppendLine("====================================");
-            sb.AppendLine("Model Number: " + m_value.ModelNumber + "");
+            sb.AppendLine("Trial Number: " + m_value.TrialNumber + "");
             sb.AppendLine("====================================");
         }
 

--- a/Tunny/UI/MessageBox.cs
+++ b/Tunny/UI/MessageBox.cs
@@ -25,6 +25,10 @@ namespace Tunny.UI
                 dialogResult = MessageBox.Show(ownerWindow, message, caption, buttons, icon);
                 f.TopMost = false;
             }
+            if (dialogResult != DialogResult.None && dialogResult != DialogResult.OK)
+            {
+                TLog.Info($"Dialog result: {dialogResult}");
+            }
             return dialogResult;
         }
 

--- a/Tunny/UI/MessageBox.cs
+++ b/Tunny/UI/MessageBox.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Windows.Forms;
 
 using Tunny.Core.Util;
@@ -10,11 +11,18 @@ namespace Tunny.UI
         {
             DialogResult dialogResult = DialogResult.None;
             WriteLog(message, icon);
+
+            IntPtr ownerHWND = TEnvVariables.GrasshopperWindowHandle == IntPtr.Zero
+                ? Rhino.RhinoApp.MainWindowHandle()
+                : TEnvVariables.GrasshopperWindowHandle;
+            var ownerWindow = new NativeWindow();
+            ownerWindow.AssignHandle(ownerHWND);
+
             using (var f = new Form())
             {
                 f.Owner = Grasshopper.Instances.DocumentEditor;
                 f.TopMost = true;
-                dialogResult = MessageBox.Show(message, caption, buttons, icon);
+                dialogResult = MessageBox.Show(ownerWindow, message, caption, buttons, icon);
                 f.TopMost = false;
             }
             return dialogResult;

--- a/Tunny/UI/OptimizationWindow.Designer.cs
+++ b/Tunny/UI/OptimizationWindow.Designer.cs
@@ -219,10 +219,10 @@ namespace Tunny.UI
             // 
             // optimizeRunButton
             // 
-            this.optimizeRunButton.Location = new System.Drawing.Point(48, 296);
-            this.optimizeRunButton.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            this.optimizeRunButton.Location = new System.Drawing.Point(32, 197);
+            this.optimizeRunButton.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.optimizeRunButton.Name = "optimizeRunButton";
-            this.optimizeRunButton.Size = new System.Drawing.Size(153, 34);
+            this.optimizeRunButton.Size = new System.Drawing.Size(102, 23);
             this.optimizeRunButton.TabIndex = 0;
             this.optimizeRunButton.Text = "RunOptimize";
             this.optimizeRunButton.UseVisualStyleBackColor = true;
@@ -231,10 +231,10 @@ namespace Tunny.UI
             // optimizeStopButton
             // 
             this.optimizeStopButton.Enabled = false;
-            this.optimizeStopButton.Location = new System.Drawing.Point(246, 296);
-            this.optimizeStopButton.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            this.optimizeStopButton.Location = new System.Drawing.Point(164, 197);
+            this.optimizeStopButton.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.optimizeStopButton.Name = "optimizeStopButton";
-            this.optimizeStopButton.Size = new System.Drawing.Size(126, 34);
+            this.optimizeStopButton.Size = new System.Drawing.Size(84, 23);
             this.optimizeStopButton.TabIndex = 1;
             this.optimizeStopButton.Text = "Stop";
             this.optimizeStopButton.UseVisualStyleBackColor = true;
@@ -242,15 +242,15 @@ namespace Tunny.UI
             // 
             // nTrialNumUpDown
             // 
-            this.nTrialNumUpDown.Location = new System.Drawing.Point(246, 52);
-            this.nTrialNumUpDown.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            this.nTrialNumUpDown.Location = new System.Drawing.Point(164, 35);
+            this.nTrialNumUpDown.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.nTrialNumUpDown.Maximum = new decimal(new int[] {
             10000,
             0,
             0,
             0});
             this.nTrialNumUpDown.Name = "nTrialNumUpDown";
-            this.nTrialNumUpDown.Size = new System.Drawing.Size(165, 30);
+            this.nTrialNumUpDown.Size = new System.Drawing.Size(110, 23);
             this.nTrialNumUpDown.TabIndex = 2;
             this.nTrialNumUpDown.ThousandsSeparator = true;
             this.nTrialNumUpDown.Value = new decimal(new int[] {
@@ -262,20 +262,19 @@ namespace Tunny.UI
             // nTrialText
             // 
             this.nTrialText.AutoSize = true;
-            this.nTrialText.Location = new System.Drawing.Point(15, 56);
-            this.nTrialText.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.nTrialText.Location = new System.Drawing.Point(10, 37);
             this.nTrialText.Name = "nTrialText";
-            this.nTrialText.Size = new System.Drawing.Size(151, 23);
+            this.nTrialText.Size = new System.Drawing.Size(102, 15);
             this.nTrialText.TabIndex = 3;
             this.nTrialText.Text = "Number of trials";
             // 
             // continueStudyCheckBox
             // 
             this.continueStudyCheckBox.AutoSize = true;
-            this.continueStudyCheckBox.Location = new System.Drawing.Point(164, 72);
-            this.continueStudyCheckBox.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            this.continueStudyCheckBox.Location = new System.Drawing.Point(109, 48);
+            this.continueStudyCheckBox.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.continueStudyCheckBox.Name = "continueStudyCheckBox";
-            this.continueStudyCheckBox.Size = new System.Drawing.Size(114, 27);
+            this.continueStudyCheckBox.Size = new System.Drawing.Size(77, 19);
             this.continueStudyCheckBox.TabIndex = 5;
             this.continueStudyCheckBox.Text = "Continue";
             this.continueStudyCheckBox.UseVisualStyleBackColor = true;
@@ -283,10 +282,10 @@ namespace Tunny.UI
             // 
             // optimizeProgressBar
             // 
-            this.optimizeProgressBar.Location = new System.Drawing.Point(20, 340);
-            this.optimizeProgressBar.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            this.optimizeProgressBar.Location = new System.Drawing.Point(13, 227);
+            this.optimizeProgressBar.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.optimizeProgressBar.Name = "optimizeProgressBar";
-            this.optimizeProgressBar.Size = new System.Drawing.Size(388, 24);
+            this.optimizeProgressBar.Size = new System.Drawing.Size(259, 16);
             this.optimizeProgressBar.TabIndex = 6;
             // 
             // samplerComboBox
@@ -303,38 +302,36 @@ namespace Tunny.UI
             "Quasi-MonteCarlo",
             "Random",
             "BruteForce"});
-            this.samplerComboBox.Location = new System.Drawing.Point(105, 16);
-            this.samplerComboBox.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.samplerComboBox.Location = new System.Drawing.Point(70, 11);
+            this.samplerComboBox.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.samplerComboBox.Name = "samplerComboBox";
-            this.samplerComboBox.Size = new System.Drawing.Size(306, 28);
+            this.samplerComboBox.Size = new System.Drawing.Size(205, 22);
             this.samplerComboBox.TabIndex = 7;
             // 
             // samplerTypeText
             // 
             this.samplerTypeText.AutoSize = true;
-            this.samplerTypeText.Location = new System.Drawing.Point(15, 16);
-            this.samplerTypeText.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.samplerTypeText.Location = new System.Drawing.Point(10, 11);
             this.samplerTypeText.Name = "samplerTypeText";
-            this.samplerTypeText.Size = new System.Drawing.Size(81, 23);
+            this.samplerTypeText.Size = new System.Drawing.Size(56, 15);
             this.samplerTypeText.TabIndex = 8;
             this.samplerTypeText.Text = "Sampler";
             // 
             // studyNameLabel
             // 
             this.studyNameLabel.AutoSize = true;
-            this.studyNameLabel.Location = new System.Drawing.Point(8, 30);
-            this.studyNameLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.studyNameLabel.Location = new System.Drawing.Point(5, 20);
             this.studyNameLabel.Name = "studyNameLabel";
-            this.studyNameLabel.Size = new System.Drawing.Size(166, 23);
+            this.studyNameLabel.Size = new System.Drawing.Size(114, 15);
             this.studyNameLabel.TabIndex = 9;
             this.studyNameLabel.Text = "Create New Study";
             // 
             // studyNameTextBox
             // 
-            this.studyNameTextBox.Location = new System.Drawing.Point(202, 30);
-            this.studyNameTextBox.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            this.studyNameTextBox.Location = new System.Drawing.Point(135, 20);
+            this.studyNameTextBox.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.studyNameTextBox.Name = "studyNameTextBox";
-            this.studyNameTextBox.Size = new System.Drawing.Size(180, 30);
+            this.studyNameTextBox.Size = new System.Drawing.Size(121, 23);
             this.studyNameTextBox.TabIndex = 10;
             this.studyNameTextBox.Text = "study1";
             // 
@@ -345,11 +342,11 @@ namespace Tunny.UI
             this.optimizeTabControl.Controls.Add(this.outputTabPage);
             this.optimizeTabControl.Controls.Add(this.settingsTabPage);
             this.optimizeTabControl.Controls.Add(this.fileTabPage);
-            this.optimizeTabControl.Location = new System.Drawing.Point(0, -2);
-            this.optimizeTabControl.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            this.optimizeTabControl.Location = new System.Drawing.Point(0, -1);
+            this.optimizeTabControl.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.optimizeTabControl.Name = "optimizeTabControl";
             this.optimizeTabControl.SelectedIndex = 0;
-            this.optimizeTabControl.Size = new System.Drawing.Size(436, 478);
+            this.optimizeTabControl.Size = new System.Drawing.Size(291, 319);
             this.optimizeTabControl.TabIndex = 11;
             // 
             // optimizeTabPage
@@ -368,11 +365,11 @@ namespace Tunny.UI
             this.optimizeTabPage.Controls.Add(this.nTrialNumUpDown);
             this.optimizeTabPage.Controls.Add(this.optimizeProgressBar);
             this.optimizeTabPage.Controls.Add(this.nTrialText);
-            this.optimizeTabPage.Location = new System.Drawing.Point(4, 32);
-            this.optimizeTabPage.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            this.optimizeTabPage.Location = new System.Drawing.Point(4, 24);
+            this.optimizeTabPage.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.optimizeTabPage.Name = "optimizeTabPage";
-            this.optimizeTabPage.Padding = new System.Windows.Forms.Padding(4, 6, 4, 6);
-            this.optimizeTabPage.Size = new System.Drawing.Size(428, 442);
+            this.optimizeTabPage.Padding = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.optimizeTabPage.Size = new System.Drawing.Size(283, 291);
             this.optimizeTabPage.TabIndex = 0;
             this.optimizeTabPage.Text = "Optimize";
             this.optimizeTabPage.UseVisualStyleBackColor = true;
@@ -380,9 +377,10 @@ namespace Tunny.UI
             // ShowRealtimeResultCheckBox
             // 
             this.ShowRealtimeResultCheckBox.AutoSize = true;
-            this.ShowRealtimeResultCheckBox.Location = new System.Drawing.Point(141, 382);
+            this.ShowRealtimeResultCheckBox.Location = new System.Drawing.Point(94, 255);
+            this.ShowRealtimeResultCheckBox.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.ShowRealtimeResultCheckBox.Name = "ShowRealtimeResultCheckBox";
-            this.ShowRealtimeResultCheckBox.Size = new System.Drawing.Size(22, 21);
+            this.ShowRealtimeResultCheckBox.Size = new System.Drawing.Size(15, 14);
             this.ShowRealtimeResultCheckBox.TabIndex = 17;
             this.toolTip1.SetToolTip(this.ShowRealtimeResultCheckBox, "Enable real-time display of BestValue during optimization.\r\nIf enabled, optimizat" +
         "ion will slow down as the number of trials increases.");
@@ -391,27 +389,30 @@ namespace Tunny.UI
             // EstimatedTimeRemainingLabel
             // 
             this.EstimatedTimeRemainingLabel.AutoSize = true;
-            this.EstimatedTimeRemainingLabel.Location = new System.Drawing.Point(21, 411);
+            this.EstimatedTimeRemainingLabel.Location = new System.Drawing.Point(14, 274);
+            this.EstimatedTimeRemainingLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.EstimatedTimeRemainingLabel.Name = "EstimatedTimeRemainingLabel";
-            this.EstimatedTimeRemainingLabel.Size = new System.Drawing.Size(272, 23);
+            this.EstimatedTimeRemainingLabel.Size = new System.Drawing.Size(184, 15);
             this.EstimatedTimeRemainingLabel.TabIndex = 16;
             this.EstimatedTimeRemainingLabel.Text = "Estimated Time Remaining: #";
             // 
             // optimizeBestValueLabel
             // 
             this.optimizeBestValueLabel.AutoSize = true;
-            this.optimizeBestValueLabel.Location = new System.Drawing.Point(170, 380);
+            this.optimizeBestValueLabel.Location = new System.Drawing.Point(113, 253);
+            this.optimizeBestValueLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.optimizeBestValueLabel.Name = "optimizeBestValueLabel";
-            this.optimizeBestValueLabel.Size = new System.Drawing.Size(129, 23);
+            this.optimizeBestValueLabel.Size = new System.Drawing.Size(87, 15);
             this.optimizeBestValueLabel.TabIndex = 15;
             this.optimizeBestValueLabel.Text = "BestValue: # ";
             // 
             // optimizeTrialNumLabel
             // 
             this.optimizeTrialNumLabel.AutoSize = true;
-            this.optimizeTrialNumLabel.Location = new System.Drawing.Point(21, 380);
+            this.optimizeTrialNumLabel.Location = new System.Drawing.Point(14, 253);
+            this.optimizeTrialNumLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.optimizeTrialNumLabel.Name = "optimizeTrialNumLabel";
-            this.optimizeTrialNumLabel.Size = new System.Drawing.Size(80, 23);
+            this.optimizeTrialNumLabel.Size = new System.Drawing.Size(55, 15);
             this.optimizeTrialNumLabel.TabIndex = 14;
             this.optimizeTrialNumLabel.Text = "Trial: # ";
             // 
@@ -424,9 +425,11 @@ namespace Tunny.UI
             this.groupBox2.Controls.Add(this.studyNameLabel);
             this.groupBox2.Controls.Add(this.continueStudyCheckBox);
             this.groupBox2.Controls.Add(this.studyNameTextBox);
-            this.groupBox2.Location = new System.Drawing.Point(20, 134);
+            this.groupBox2.Location = new System.Drawing.Point(13, 89);
+            this.groupBox2.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Size = new System.Drawing.Size(390, 153);
+            this.groupBox2.Padding = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.groupBox2.Size = new System.Drawing.Size(260, 102);
             this.groupBox2.TabIndex = 13;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "Study Name";
@@ -434,10 +437,10 @@ namespace Tunny.UI
             // inMemoryCheckBox
             // 
             this.inMemoryCheckBox.AutoSize = true;
-            this.inMemoryCheckBox.Location = new System.Drawing.Point(12, 69);
-            this.inMemoryCheckBox.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            this.inMemoryCheckBox.Location = new System.Drawing.Point(8, 46);
+            this.inMemoryCheckBox.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.inMemoryCheckBox.Name = "inMemoryCheckBox";
-            this.inMemoryCheckBox.Size = new System.Drawing.Size(124, 27);
+            this.inMemoryCheckBox.Size = new System.Drawing.Size(86, 19);
             this.inMemoryCheckBox.TabIndex = 15;
             this.inMemoryCheckBox.Text = "InMemory";
             this.inMemoryCheckBox.UseVisualStyleBackColor = true;
@@ -446,26 +449,29 @@ namespace Tunny.UI
             // existedStudyNameLabel
             // 
             this.existedStudyNameLabel.AutoSize = true;
-            this.existedStudyNameLabel.Location = new System.Drawing.Point(8, 111);
+            this.existedStudyNameLabel.Location = new System.Drawing.Point(5, 74);
+            this.existedStudyNameLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.existedStudyNameLabel.Name = "existedStudyNameLabel";
-            this.existedStudyNameLabel.Size = new System.Drawing.Size(135, 23);
+            this.existedStudyNameLabel.Size = new System.Drawing.Size(90, 15);
             this.existedStudyNameLabel.TabIndex = 14;
             this.existedStudyNameLabel.Text = "Existing Study";
             // 
             // existingStudyComboBox
             // 
             this.existingStudyComboBox.FormattingEnabled = true;
-            this.existingStudyComboBox.Location = new System.Drawing.Point(202, 108);
+            this.existingStudyComboBox.Location = new System.Drawing.Point(135, 72);
+            this.existingStudyComboBox.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.existingStudyComboBox.Name = "existingStudyComboBox";
-            this.existingStudyComboBox.Size = new System.Drawing.Size(180, 31);
+            this.existingStudyComboBox.Size = new System.Drawing.Size(121, 23);
             this.existingStudyComboBox.TabIndex = 13;
             // 
             // copyStudyCheckBox
             // 
             this.copyStudyCheckBox.AutoSize = true;
-            this.copyStudyCheckBox.Location = new System.Drawing.Point(304, 72);
+            this.copyStudyCheckBox.Location = new System.Drawing.Point(203, 48);
+            this.copyStudyCheckBox.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.copyStudyCheckBox.Name = "copyStudyCheckBox";
-            this.copyStudyCheckBox.Size = new System.Drawing.Size(80, 27);
+            this.copyStudyCheckBox.Size = new System.Drawing.Size(55, 19);
             this.copyStudyCheckBox.TabIndex = 12;
             this.copyStudyCheckBox.Text = "Copy";
             this.copyStudyCheckBox.UseVisualStyleBackColor = true;
@@ -473,15 +479,15 @@ namespace Tunny.UI
             // 
             // timeoutNumUpDown
             // 
-            this.timeoutNumUpDown.Location = new System.Drawing.Point(246, 94);
-            this.timeoutNumUpDown.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            this.timeoutNumUpDown.Location = new System.Drawing.Point(164, 63);
+            this.timeoutNumUpDown.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.timeoutNumUpDown.Maximum = new decimal(new int[] {
             10000000,
             0,
             0,
             0});
             this.timeoutNumUpDown.Name = "timeoutNumUpDown";
-            this.timeoutNumUpDown.Size = new System.Drawing.Size(164, 30);
+            this.timeoutNumUpDown.Size = new System.Drawing.Size(109, 23);
             this.timeoutNumUpDown.TabIndex = 12;
             this.timeoutNumUpDown.ThousandsSeparator = true;
             this.toolTip1.SetToolTip(this.timeoutNumUpDown, "After this time has elapsed, optimization stops.\r\nIf 0 is entered, no stop by tim" +
@@ -490,10 +496,9 @@ namespace Tunny.UI
             // Timeout
             // 
             this.Timeout.AutoSize = true;
-            this.Timeout.Location = new System.Drawing.Point(15, 94);
-            this.Timeout.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.Timeout.Location = new System.Drawing.Point(10, 63);
             this.Timeout.Name = "Timeout";
-            this.Timeout.Size = new System.Drawing.Size(132, 23);
+            this.Timeout.Size = new System.Drawing.Size(89, 15);
             this.Timeout.TabIndex = 11;
             this.Timeout.Text = "Timeout (sec)";
             // 
@@ -514,21 +519,20 @@ namespace Tunny.UI
             this.visualizeTabPage.Controls.Add(this.visualizeNumClusterLabel);
             this.visualizeTabPage.Controls.Add(this.visualizeShowPlotButton);
             this.visualizeTabPage.Controls.Add(this.visualizeSavePlotButton);
-            this.visualizeTabPage.Location = new System.Drawing.Point(4, 32);
-            this.visualizeTabPage.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            this.visualizeTabPage.Location = new System.Drawing.Point(4, 24);
+            this.visualizeTabPage.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.visualizeTabPage.Name = "visualizeTabPage";
-            this.visualizeTabPage.Padding = new System.Windows.Forms.Padding(4, 6, 4, 6);
-            this.visualizeTabPage.Size = new System.Drawing.Size(428, 442);
+            this.visualizeTabPage.Padding = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.visualizeTabPage.Size = new System.Drawing.Size(283, 291);
             this.visualizeTabPage.TabIndex = 1;
             this.visualizeTabPage.Text = "Visualize";
             this.visualizeTabPage.UseVisualStyleBackColor = true;
             // 
             // ttDesignExplorerButton
             // 
-            this.ttDesignExplorerButton.Location = new System.Drawing.Point(209, 10);
-            this.ttDesignExplorerButton.Margin = new System.Windows.Forms.Padding(4);
+            this.ttDesignExplorerButton.Location = new System.Drawing.Point(139, 7);
             this.ttDesignExplorerButton.Name = "ttDesignExplorerButton";
-            this.ttDesignExplorerButton.Size = new System.Drawing.Size(203, 60);
+            this.ttDesignExplorerButton.Size = new System.Drawing.Size(135, 40);
             this.ttDesignExplorerButton.TabIndex = 28;
             this.ttDesignExplorerButton.Text = "Open TT-DesignExplorer";
             this.ttDesignExplorerButton.UseVisualStyleBackColor = true;
@@ -540,9 +544,10 @@ namespace Tunny.UI
             this.visualizeIncludeDominatedCheckBox.Checked = true;
             this.visualizeIncludeDominatedCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
             this.visualizeIncludeDominatedCheckBox.Enabled = false;
-            this.visualizeIncludeDominatedCheckBox.Location = new System.Drawing.Point(26, 404);
+            this.visualizeIncludeDominatedCheckBox.Location = new System.Drawing.Point(17, 269);
+            this.visualizeIncludeDominatedCheckBox.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.visualizeIncludeDominatedCheckBox.Name = "visualizeIncludeDominatedCheckBox";
-            this.visualizeIncludeDominatedCheckBox.Size = new System.Drawing.Size(380, 27);
+            this.visualizeIncludeDominatedCheckBox.Size = new System.Drawing.Size(255, 19);
             this.visualizeIncludeDominatedCheckBox.TabIndex = 27;
             this.visualizeIncludeDominatedCheckBox.Text = "Include dominated trials in pareto front";
             this.visualizeIncludeDominatedCheckBox.UseVisualStyleBackColor = true;
@@ -550,38 +555,42 @@ namespace Tunny.UI
             // visualizeTypeLabel
             // 
             this.visualizeTypeLabel.AutoSize = true;
-            this.visualizeTypeLabel.Location = new System.Drawing.Point(22, 130);
+            this.visualizeTypeLabel.Location = new System.Drawing.Point(15, 87);
+            this.visualizeTypeLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.visualizeTypeLabel.Name = "visualizeTypeLabel";
-            this.visualizeTypeLabel.Size = new System.Drawing.Size(132, 23);
+            this.visualizeTypeLabel.Size = new System.Drawing.Size(89, 15);
             this.visualizeTypeLabel.TabIndex = 22;
             this.visualizeTypeLabel.Text = "Visualize Type";
             // 
             // visualizeTargetStudyNameLabel
             // 
             this.visualizeTargetStudyNameLabel.AutoSize = true;
-            this.visualizeTargetStudyNameLabel.Location = new System.Drawing.Point(22, 94);
+            this.visualizeTargetStudyNameLabel.Location = new System.Drawing.Point(15, 63);
+            this.visualizeTargetStudyNameLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.visualizeTargetStudyNameLabel.Name = "visualizeTargetStudyNameLabel";
-            this.visualizeTargetStudyNameLabel.Size = new System.Drawing.Size(120, 23);
+            this.visualizeTargetStudyNameLabel.Size = new System.Drawing.Size(83, 15);
             this.visualizeTargetStudyNameLabel.TabIndex = 21;
             this.visualizeTargetStudyNameLabel.Text = "Target Study";
             // 
             // visualizeObjectiveListBox
             // 
             this.visualizeObjectiveListBox.FormattingEnabled = true;
-            this.visualizeObjectiveListBox.ItemHeight = 23;
-            this.visualizeObjectiveListBox.Location = new System.Drawing.Point(222, 218);
+            this.visualizeObjectiveListBox.ItemHeight = 15;
+            this.visualizeObjectiveListBox.Location = new System.Drawing.Point(148, 145);
+            this.visualizeObjectiveListBox.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.visualizeObjectiveListBox.Name = "visualizeObjectiveListBox";
             this.visualizeObjectiveListBox.ScrollAlwaysVisible = true;
             this.visualizeObjectiveListBox.SelectionMode = System.Windows.Forms.SelectionMode.MultiSimple;
-            this.visualizeObjectiveListBox.Size = new System.Drawing.Size(190, 73);
+            this.visualizeObjectiveListBox.Size = new System.Drawing.Size(128, 49);
             this.visualizeObjectiveListBox.TabIndex = 26;
             // 
             // visualizeTargetStudyComboBox
             // 
             this.visualizeTargetStudyComboBox.FormattingEnabled = true;
-            this.visualizeTargetStudyComboBox.Location = new System.Drawing.Point(184, 90);
+            this.visualizeTargetStudyComboBox.Location = new System.Drawing.Point(123, 60);
+            this.visualizeTargetStudyComboBox.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.visualizeTargetStudyComboBox.Name = "visualizeTargetStudyComboBox";
-            this.visualizeTargetStudyComboBox.Size = new System.Drawing.Size(216, 31);
+            this.visualizeTargetStudyComboBox.Size = new System.Drawing.Size(145, 23);
             this.visualizeTargetStudyComboBox.TabIndex = 20;
             this.visualizeTargetStudyComboBox.SelectedIndexChanged += new System.EventHandler(this.VisualizeTargetStudy_Changed);
             // 
@@ -598,44 +607,47 @@ namespace Tunny.UI
             "slice",
             "hypervolume",
             "clustering"});
-            this.visualizeTypeComboBox.Location = new System.Drawing.Point(184, 130);
-            this.visualizeTypeComboBox.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            this.visualizeTypeComboBox.Location = new System.Drawing.Point(123, 87);
+            this.visualizeTypeComboBox.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.visualizeTypeComboBox.Name = "visualizeTypeComboBox";
-            this.visualizeTypeComboBox.Size = new System.Drawing.Size(216, 31);
+            this.visualizeTypeComboBox.Size = new System.Drawing.Size(145, 23);
             this.visualizeTypeComboBox.TabIndex = 0;
             this.visualizeTypeComboBox.SelectedIndexChanged += new System.EventHandler(this.VisualizeType_Changed);
             // 
             // visualizeVariableListBox
             // 
             this.visualizeVariableListBox.FormattingEnabled = true;
-            this.visualizeVariableListBox.ItemHeight = 23;
-            this.visualizeVariableListBox.Location = new System.Drawing.Point(26, 218);
+            this.visualizeVariableListBox.ItemHeight = 15;
+            this.visualizeVariableListBox.Location = new System.Drawing.Point(17, 145);
+            this.visualizeVariableListBox.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.visualizeVariableListBox.Name = "visualizeVariableListBox";
             this.visualizeVariableListBox.ScrollAlwaysVisible = true;
             this.visualizeVariableListBox.SelectionMode = System.Windows.Forms.SelectionMode.MultiSimple;
-            this.visualizeVariableListBox.Size = new System.Drawing.Size(190, 73);
+            this.visualizeVariableListBox.Size = new System.Drawing.Size(128, 49);
             this.visualizeVariableListBox.TabIndex = 25;
             // 
             // visualizeTargetVariableLabel
             // 
             this.visualizeTargetVariableLabel.AutoSize = true;
-            this.visualizeTargetVariableLabel.Location = new System.Drawing.Point(218, 180);
+            this.visualizeTargetVariableLabel.Location = new System.Drawing.Point(145, 120);
+            this.visualizeTargetVariableLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.visualizeTargetVariableLabel.Name = "visualizeTargetVariableLabel";
-            this.visualizeTargetVariableLabel.Size = new System.Drawing.Size(139, 23);
+            this.visualizeTargetVariableLabel.Size = new System.Drawing.Size(95, 15);
             this.visualizeTargetVariableLabel.TabIndex = 24;
             this.visualizeTargetVariableLabel.Text = "Target Variable";
             // 
             // visualizeClusterNumUpDown
             // 
             this.visualizeClusterNumUpDown.Enabled = false;
-            this.visualizeClusterNumUpDown.Location = new System.Drawing.Point(308, 358);
+            this.visualizeClusterNumUpDown.Location = new System.Drawing.Point(205, 239);
+            this.visualizeClusterNumUpDown.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.visualizeClusterNumUpDown.Minimum = new decimal(new int[] {
             1,
             0,
             0,
             0});
             this.visualizeClusterNumUpDown.Name = "visualizeClusterNumUpDown";
-            this.visualizeClusterNumUpDown.Size = new System.Drawing.Size(93, 30);
+            this.visualizeClusterNumUpDown.Size = new System.Drawing.Size(62, 23);
             this.visualizeClusterNumUpDown.TabIndex = 13;
             this.visualizeClusterNumUpDown.Value = new decimal(new int[] {
             3,
@@ -646,18 +658,18 @@ namespace Tunny.UI
             // visualizeTargetObjectiveLabel
             // 
             this.visualizeTargetObjectiveLabel.AutoSize = true;
-            this.visualizeTargetObjectiveLabel.Location = new System.Drawing.Point(22, 180);
+            this.visualizeTargetObjectiveLabel.Location = new System.Drawing.Point(15, 120);
+            this.visualizeTargetObjectiveLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.visualizeTargetObjectiveLabel.Name = "visualizeTargetObjectiveLabel";
-            this.visualizeTargetObjectiveLabel.Size = new System.Drawing.Size(152, 23);
+            this.visualizeTargetObjectiveLabel.Size = new System.Drawing.Size(104, 15);
             this.visualizeTargetObjectiveLabel.TabIndex = 23;
             this.visualizeTargetObjectiveLabel.Text = "Target Objective";
             // 
             // dashboardButton
             // 
-            this.dashboardButton.Location = new System.Drawing.Point(11, 10);
-            this.dashboardButton.Margin = new System.Windows.Forms.Padding(4);
+            this.dashboardButton.Location = new System.Drawing.Point(7, 7);
             this.dashboardButton.Name = "dashboardButton";
-            this.dashboardButton.Size = new System.Drawing.Size(190, 60);
+            this.dashboardButton.Size = new System.Drawing.Size(127, 40);
             this.dashboardButton.TabIndex = 11;
             this.dashboardButton.Text = "Open Optuna-Dashboard";
             this.dashboardButton.UseVisualStyleBackColor = true;
@@ -666,18 +678,19 @@ namespace Tunny.UI
             // visualizeNumClusterLabel
             // 
             this.visualizeNumClusterLabel.AutoSize = true;
-            this.visualizeNumClusterLabel.Location = new System.Drawing.Point(22, 366);
+            this.visualizeNumClusterLabel.Location = new System.Drawing.Point(15, 244);
+            this.visualizeNumClusterLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.visualizeNumClusterLabel.Name = "visualizeNumClusterLabel";
-            this.visualizeNumClusterLabel.Size = new System.Drawing.Size(166, 23);
+            this.visualizeNumClusterLabel.Size = new System.Drawing.Size(112, 15);
             this.visualizeNumClusterLabel.TabIndex = 14;
             this.visualizeNumClusterLabel.Text = "Number of cluster";
             // 
             // visualizeShowPlotButton
             // 
-            this.visualizeShowPlotButton.Location = new System.Drawing.Point(36, 304);
-            this.visualizeShowPlotButton.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            this.visualizeShowPlotButton.Location = new System.Drawing.Point(24, 203);
+            this.visualizeShowPlotButton.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.visualizeShowPlotButton.Name = "visualizeShowPlotButton";
-            this.visualizeShowPlotButton.Size = new System.Drawing.Size(165, 34);
+            this.visualizeShowPlotButton.Size = new System.Drawing.Size(110, 23);
             this.visualizeShowPlotButton.TabIndex = 2;
             this.visualizeShowPlotButton.Text = "Show";
             this.visualizeShowPlotButton.UseVisualStyleBackColor = true;
@@ -685,9 +698,10 @@ namespace Tunny.UI
             // 
             // visualizeSavePlotButton
             // 
-            this.visualizeSavePlotButton.Location = new System.Drawing.Point(236, 304);
+            this.visualizeSavePlotButton.Location = new System.Drawing.Point(157, 203);
+            this.visualizeSavePlotButton.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.visualizeSavePlotButton.Name = "visualizeSavePlotButton";
-            this.visualizeSavePlotButton.Size = new System.Drawing.Size(165, 34);
+            this.visualizeSavePlotButton.Size = new System.Drawing.Size(110, 23);
             this.visualizeSavePlotButton.TabIndex = 3;
             this.visualizeSavePlotButton.Text = "Save";
             this.visualizeSavePlotButton.UseVisualStyleBackColor = true;
@@ -702,10 +716,11 @@ namespace Tunny.UI
             this.outputTabPage.Controls.Add(this.outputParatoSolutionButton);
             this.outputTabPage.Controls.Add(this.outputStopButton);
             this.outputTabPage.Controls.Add(this.outputProgressBar);
-            this.outputTabPage.Location = new System.Drawing.Point(4, 32);
+            this.outputTabPage.Location = new System.Drawing.Point(4, 24);
+            this.outputTabPage.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.outputTabPage.Name = "outputTabPage";
-            this.outputTabPage.Padding = new System.Windows.Forms.Padding(3);
-            this.outputTabPage.Size = new System.Drawing.Size(428, 442);
+            this.outputTabPage.Padding = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.outputTabPage.Size = new System.Drawing.Size(283, 291);
             this.outputTabPage.TabIndex = 3;
             this.outputTabPage.Text = "Output";
             this.outputTabPage.UseVisualStyleBackColor = true;
@@ -715,67 +730,67 @@ namespace Tunny.UI
             this.outputUseModelNumberGroupBox.Controls.Add(this.outputModelNumTextBox);
             this.outputUseModelNumberGroupBox.Controls.Add(this.outputModelNumberButton);
             this.outputUseModelNumberGroupBox.Controls.Add(this.reflectToSliderButton);
-            this.outputUseModelNumberGroupBox.Location = new System.Drawing.Point(8, 146);
+            this.outputUseModelNumberGroupBox.Location = new System.Drawing.Point(5, 97);
+            this.outputUseModelNumberGroupBox.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.outputUseModelNumberGroupBox.Name = "outputUseModelNumberGroupBox";
-            this.outputUseModelNumberGroupBox.Size = new System.Drawing.Size(393, 202);
+            this.outputUseModelNumberGroupBox.Padding = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.outputUseModelNumberGroupBox.Size = new System.Drawing.Size(262, 135);
             this.outputUseModelNumberGroupBox.TabIndex = 21;
             this.outputUseModelNumberGroupBox.TabStop = false;
-            this.outputUseModelNumberGroupBox.Text = "Use Model Number";
+            this.outputUseModelNumberGroupBox.Text = "Use Trial Number";
             // 
             // outputModelNumTextBox
             // 
-            this.outputModelNumTextBox.Location = new System.Drawing.Point(21, 45);
-            this.outputModelNumTextBox.Margin = new System.Windows.Forms.Padding(4);
+            this.outputModelNumTextBox.Location = new System.Drawing.Point(14, 30);
             this.outputModelNumTextBox.Name = "outputModelNumTextBox";
-            this.outputModelNumTextBox.Size = new System.Drawing.Size(360, 30);
+            this.outputModelNumTextBox.Size = new System.Drawing.Size(241, 23);
             this.outputModelNumTextBox.TabIndex = 12;
             this.outputModelNumTextBox.Text = "0";
             // 
             // outputModelNumberButton
             // 
-            this.outputModelNumberButton.Location = new System.Drawing.Point(206, 94);
-            this.outputModelNumberButton.Margin = new System.Windows.Forms.Padding(4);
+            this.outputModelNumberButton.Location = new System.Drawing.Point(137, 63);
             this.outputModelNumberButton.Name = "outputModelNumberButton";
-            this.outputModelNumberButton.Size = new System.Drawing.Size(176, 82);
+            this.outputModelNumberButton.Size = new System.Drawing.Size(117, 55);
             this.outputModelNumberButton.TabIndex = 13;
-            this.outputModelNumberButton.Text = "Output the above number models";
+            this.outputModelNumberButton.Text = "Output\r\nthe trial to fish";
             this.outputModelNumberButton.UseVisualStyleBackColor = true;
-            this.outputModelNumberButton.Click += new System.EventHandler(this.OutputModelNumberButton_Click);
+            this.outputModelNumberButton.Click += new System.EventHandler(this.OutputTrialNumberButton_Click);
             // 
             // reflectToSliderButton
             // 
-            this.reflectToSliderButton.Location = new System.Drawing.Point(21, 94);
-            this.reflectToSliderButton.Margin = new System.Windows.Forms.Padding(4);
+            this.reflectToSliderButton.Location = new System.Drawing.Point(14, 63);
             this.reflectToSliderButton.Name = "reflectToSliderButton";
-            this.reflectToSliderButton.Size = new System.Drawing.Size(176, 82);
+            this.reflectToSliderButton.Size = new System.Drawing.Size(117, 55);
             this.reflectToSliderButton.TabIndex = 16;
-            this.reflectToSliderButton.Text = "Reflect the result on the sliders";
+            this.reflectToSliderButton.Text = "Reinstate\r\nthe trial to the sliders";
             this.reflectToSliderButton.UseVisualStyleBackColor = true;
             this.reflectToSliderButton.Click += new System.EventHandler(this.ReflectToSliderButton_Click);
             // 
             // outputTargetStudyComboBox
             // 
             this.outputTargetStudyComboBox.FormattingEnabled = true;
-            this.outputTargetStudyComboBox.Location = new System.Drawing.Point(170, 24);
+            this.outputTargetStudyComboBox.Location = new System.Drawing.Point(113, 16);
+            this.outputTargetStudyComboBox.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.outputTargetStudyComboBox.Name = "outputTargetStudyComboBox";
-            this.outputTargetStudyComboBox.Size = new System.Drawing.Size(220, 31);
+            this.outputTargetStudyComboBox.Size = new System.Drawing.Size(148, 23);
             this.outputTargetStudyComboBox.TabIndex = 20;
             // 
             // outputTargetStudyLabel
             // 
             this.outputTargetStudyLabel.AutoSize = true;
-            this.outputTargetStudyLabel.Location = new System.Drawing.Point(34, 27);
+            this.outputTargetStudyLabel.Location = new System.Drawing.Point(23, 18);
+            this.outputTargetStudyLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.outputTargetStudyLabel.Name = "outputTargetStudyLabel";
-            this.outputTargetStudyLabel.Size = new System.Drawing.Size(120, 23);
+            this.outputTargetStudyLabel.Size = new System.Drawing.Size(83, 15);
             this.outputTargetStudyLabel.TabIndex = 19;
             this.outputTargetStudyLabel.Text = "Target Study";
             // 
             // outputAllTrialsButton
             // 
-            this.outputAllTrialsButton.Location = new System.Drawing.Point(214, 84);
-            this.outputAllTrialsButton.Margin = new System.Windows.Forms.Padding(4);
+            this.outputAllTrialsButton.Location = new System.Drawing.Point(143, 56);
             this.outputAllTrialsButton.Name = "outputAllTrialsButton";
-            this.outputAllTrialsButton.Size = new System.Drawing.Size(176, 34);
+            this.outputAllTrialsButton.Size = new System.Drawing.Size(117, 23);
             this.outputAllTrialsButton.TabIndex = 18;
             this.outputAllTrialsButton.Text = "All trials";
             this.outputAllTrialsButton.UseVisualStyleBackColor = true;
@@ -783,10 +798,9 @@ namespace Tunny.UI
             // 
             // outputParatoSolutionButton
             // 
-            this.outputParatoSolutionButton.Location = new System.Drawing.Point(28, 84);
-            this.outputParatoSolutionButton.Margin = new System.Windows.Forms.Padding(4);
+            this.outputParatoSolutionButton.Location = new System.Drawing.Point(19, 56);
             this.outputParatoSolutionButton.Name = "outputParatoSolutionButton";
-            this.outputParatoSolutionButton.Size = new System.Drawing.Size(176, 34);
+            this.outputParatoSolutionButton.Size = new System.Drawing.Size(117, 23);
             this.outputParatoSolutionButton.TabIndex = 17;
             this.outputParatoSolutionButton.Text = "Pareto solutions";
             this.outputParatoSolutionButton.UseVisualStyleBackColor = true;
@@ -795,10 +809,9 @@ namespace Tunny.UI
             // outputStopButton
             // 
             this.outputStopButton.Enabled = false;
-            this.outputStopButton.Location = new System.Drawing.Point(326, 372);
-            this.outputStopButton.Margin = new System.Windows.Forms.Padding(4);
+            this.outputStopButton.Location = new System.Drawing.Point(217, 248);
             this.outputStopButton.Name = "outputStopButton";
-            this.outputStopButton.Size = new System.Drawing.Size(75, 34);
+            this.outputStopButton.Size = new System.Drawing.Size(50, 23);
             this.outputStopButton.TabIndex = 15;
             this.outputStopButton.Text = "Stop";
             this.outputStopButton.UseVisualStyleBackColor = true;
@@ -806,19 +819,18 @@ namespace Tunny.UI
             // 
             // outputProgressBar
             // 
-            this.outputProgressBar.Location = new System.Drawing.Point(28, 372);
-            this.outputProgressBar.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            this.outputProgressBar.Location = new System.Drawing.Point(19, 248);
+            this.outputProgressBar.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.outputProgressBar.Name = "outputProgressBar";
-            this.outputProgressBar.Size = new System.Drawing.Size(273, 34);
+            this.outputProgressBar.Size = new System.Drawing.Size(182, 23);
             this.outputProgressBar.TabIndex = 14;
             // 
             // settingsTabPage
             // 
             this.settingsTabPage.Controls.Add(this.settingsTabControl);
-            this.settingsTabPage.Location = new System.Drawing.Point(4, 32);
-            this.settingsTabPage.Margin = new System.Windows.Forms.Padding(4);
+            this.settingsTabPage.Location = new System.Drawing.Point(4, 24);
             this.settingsTabPage.Name = "settingsTabPage";
-            this.settingsTabPage.Size = new System.Drawing.Size(428, 442);
+            this.settingsTabPage.Size = new System.Drawing.Size(283, 291);
             this.settingsTabPage.TabIndex = 2;
             this.settingsTabPage.Text = "Settings";
             this.settingsTabPage.UseVisualStyleBackColor = true;
@@ -833,10 +845,11 @@ namespace Tunny.UI
             this.settingsTabControl.Controls.Add(this.CMAES);
             this.settingsTabControl.Controls.Add(this.QMC);
             this.settingsTabControl.Controls.Add(this.Misc);
-            this.settingsTabControl.Location = new System.Drawing.Point(3, 3);
+            this.settingsTabControl.Location = new System.Drawing.Point(2, 2);
+            this.settingsTabControl.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.settingsTabControl.Name = "settingsTabControl";
             this.settingsTabControl.SelectedIndex = 0;
-            this.settingsTabControl.Size = new System.Drawing.Size(420, 429);
+            this.settingsTabControl.Size = new System.Drawing.Size(280, 286);
             this.settingsTabControl.TabIndex = 0;
             // 
             // TPE
@@ -855,19 +868,21 @@ namespace Tunny.UI
             this.TPE.Controls.Add(this.tpeConsiderEndpointsCheckBox);
             this.TPE.Controls.Add(this.tpeConsiderMagicClipCheckBox);
             this.TPE.Controls.Add(this.tpeConsiderPriorCheckBox);
-            this.TPE.Location = new System.Drawing.Point(4, 32);
+            this.TPE.Location = new System.Drawing.Point(4, 24);
+            this.TPE.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.TPE.Name = "TPE";
-            this.TPE.Padding = new System.Windows.Forms.Padding(3);
-            this.TPE.Size = new System.Drawing.Size(412, 393);
+            this.TPE.Padding = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.TPE.Size = new System.Drawing.Size(272, 258);
             this.TPE.TabIndex = 0;
             this.TPE.Text = "TPE";
             this.TPE.UseVisualStyleBackColor = true;
             // 
             // tpeDefaultButton
             // 
-            this.tpeDefaultButton.Location = new System.Drawing.Point(300, 350);
+            this.tpeDefaultButton.Location = new System.Drawing.Point(200, 233);
+            this.tpeDefaultButton.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.tpeDefaultButton.Name = "tpeDefaultButton";
-            this.tpeDefaultButton.Size = new System.Drawing.Size(100, 38);
+            this.tpeDefaultButton.Size = new System.Drawing.Size(67, 25);
             this.tpeDefaultButton.TabIndex = 13;
             this.tpeDefaultButton.Text = "Default";
             this.toolTip1.SetToolTip(this.tpeDefaultButton, "Set to Optuna\'s default value.");
@@ -877,9 +892,10 @@ namespace Tunny.UI
             // tpeNEICandidatesLabel
             // 
             this.tpeNEICandidatesLabel.AutoSize = true;
-            this.tpeNEICandidatesLabel.Location = new System.Drawing.Point(4, 44);
+            this.tpeNEICandidatesLabel.Location = new System.Drawing.Point(3, 29);
+            this.tpeNEICandidatesLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.tpeNEICandidatesLabel.Name = "tpeNEICandidatesLabel";
-            this.tpeNEICandidatesLabel.Size = new System.Drawing.Size(225, 23);
+            this.tpeNEICandidatesLabel.Size = new System.Drawing.Size(151, 15);
             this.tpeNEICandidatesLabel.TabIndex = 12;
             this.tpeNEICandidatesLabel.Text = "Number of EI candidates";
             this.toolTip1.SetToolTip(this.tpeNEICandidatesLabel, "Number of candidate samples used to calculate\r\nthe expected improvement.");
@@ -887,9 +903,10 @@ namespace Tunny.UI
             // tpeNStartupTrialsLabel
             // 
             this.tpeNStartupTrialsLabel.AutoSize = true;
-            this.tpeNStartupTrialsLabel.Location = new System.Drawing.Point(4, 8);
+            this.tpeNStartupTrialsLabel.Location = new System.Drawing.Point(3, 5);
+            this.tpeNStartupTrialsLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.tpeNStartupTrialsLabel.Name = "tpeNStartupTrialsLabel";
-            this.tpeNStartupTrialsLabel.Size = new System.Drawing.Size(219, 23);
+            this.tpeNStartupTrialsLabel.Size = new System.Drawing.Size(148, 15);
             this.tpeNStartupTrialsLabel.TabIndex = 11;
             this.tpeNStartupTrialsLabel.Text = "Number of startup trials";
             this.toolTip1.SetToolTip(this.tpeNStartupTrialsLabel, "The random sampling is used instead of the TPE algorithm\r\nuntil the given number " +
@@ -898,23 +915,25 @@ namespace Tunny.UI
             // tpePriorWeightLabel
             // 
             this.tpePriorWeightLabel.AutoSize = true;
-            this.tpePriorWeightLabel.Location = new System.Drawing.Point(4, 80);
+            this.tpePriorWeightLabel.Location = new System.Drawing.Point(3, 53);
+            this.tpePriorWeightLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.tpePriorWeightLabel.Name = "tpePriorWeightLabel";
-            this.tpePriorWeightLabel.Size = new System.Drawing.Size(118, 23);
+            this.tpePriorWeightLabel.Size = new System.Drawing.Size(78, 15);
             this.tpePriorWeightLabel.TabIndex = 10;
             this.tpePriorWeightLabel.Text = "Prior Weight";
             this.toolTip1.SetToolTip(this.tpePriorWeightLabel, "The weight of the prior.");
             // 
             // tpeEINumUpDown
             // 
-            this.tpeEINumUpDown.Location = new System.Drawing.Point(306, 42);
+            this.tpeEINumUpDown.Location = new System.Drawing.Point(204, 28);
+            this.tpeEINumUpDown.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.tpeEINumUpDown.Minimum = new decimal(new int[] {
             1,
             0,
             0,
             0});
             this.tpeEINumUpDown.Name = "tpeEINumUpDown";
-            this.tpeEINumUpDown.Size = new System.Drawing.Size(94, 30);
+            this.tpeEINumUpDown.Size = new System.Drawing.Size(63, 23);
             this.tpeEINumUpDown.TabIndex = 9;
             this.tpeEINumUpDown.Value = new decimal(new int[] {
             24,
@@ -924,7 +943,8 @@ namespace Tunny.UI
             // 
             // tpeStartupNumUpDown
             // 
-            this.tpeStartupNumUpDown.Location = new System.Drawing.Point(306, 6);
+            this.tpeStartupNumUpDown.Location = new System.Drawing.Point(204, 4);
+            this.tpeStartupNumUpDown.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.tpeStartupNumUpDown.Maximum = new decimal(new int[] {
             1000,
             0,
@@ -936,7 +956,7 @@ namespace Tunny.UI
             0,
             0});
             this.tpeStartupNumUpDown.Name = "tpeStartupNumUpDown";
-            this.tpeStartupNumUpDown.Size = new System.Drawing.Size(94, 30);
+            this.tpeStartupNumUpDown.Size = new System.Drawing.Size(63, 23);
             this.tpeStartupNumUpDown.TabIndex = 8;
             this.tpeStartupNumUpDown.Value = new decimal(new int[] {
             10,
@@ -952,9 +972,10 @@ namespace Tunny.UI
             0,
             0,
             65536});
-            this.tpePriorNumUpDown.Location = new System.Drawing.Point(306, 78);
+            this.tpePriorNumUpDown.Location = new System.Drawing.Point(204, 52);
+            this.tpePriorNumUpDown.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.tpePriorNumUpDown.Name = "tpePriorNumUpDown";
-            this.tpePriorNumUpDown.Size = new System.Drawing.Size(94, 30);
+            this.tpePriorNumUpDown.Size = new System.Drawing.Size(63, 23);
             this.tpePriorNumUpDown.TabIndex = 7;
             this.tpePriorNumUpDown.Value = new decimal(new int[] {
             10,
@@ -965,9 +986,10 @@ namespace Tunny.UI
             // tpeConstantLiarCheckBox
             // 
             this.tpeConstantLiarCheckBox.AutoSize = true;
-            this.tpeConstantLiarCheckBox.Location = new System.Drawing.Point(242, 202);
+            this.tpeConstantLiarCheckBox.Location = new System.Drawing.Point(161, 135);
+            this.tpeConstantLiarCheckBox.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.tpeConstantLiarCheckBox.Name = "tpeConstantLiarCheckBox";
-            this.tpeConstantLiarCheckBox.Size = new System.Drawing.Size(152, 27);
+            this.tpeConstantLiarCheckBox.Size = new System.Drawing.Size(104, 19);
             this.tpeConstantLiarCheckBox.TabIndex = 6;
             this.tpeConstantLiarCheckBox.Text = "Constant Liar";
             this.toolTip1.SetToolTip(this.tpeConstantLiarCheckBox, "If True, \r\npenalize running trials to avoid suggesting parameter configurations n" +
@@ -980,9 +1002,10 @@ namespace Tunny.UI
             this.tpeWarnIndependentSamplingCheckBox.Checked = true;
             this.tpeWarnIndependentSamplingCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
             this.tpeWarnIndependentSamplingCheckBox.Enabled = false;
-            this.tpeWarnIndependentSamplingCheckBox.Location = new System.Drawing.Point(4, 238);
+            this.tpeWarnIndependentSamplingCheckBox.Location = new System.Drawing.Point(3, 159);
+            this.tpeWarnIndependentSamplingCheckBox.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.tpeWarnIndependentSamplingCheckBox.Name = "tpeWarnIndependentSamplingCheckBox";
-            this.tpeWarnIndependentSamplingCheckBox.Size = new System.Drawing.Size(284, 27);
+            this.tpeWarnIndependentSamplingCheckBox.Size = new System.Drawing.Size(191, 19);
             this.tpeWarnIndependentSamplingCheckBox.TabIndex = 5;
             this.tpeWarnIndependentSamplingCheckBox.Text = "Warn Independent Sampling";
             this.toolTip1.SetToolTip(this.tpeWarnIndependentSamplingCheckBox, "If this is True and multivariate=True, \r\na warning message is emitted\r\nwhen the v" +
@@ -993,9 +1016,10 @@ namespace Tunny.UI
             // tpeGroupCheckBox
             // 
             this.tpeGroupCheckBox.AutoSize = true;
-            this.tpeGroupCheckBox.Location = new System.Drawing.Point(242, 170);
+            this.tpeGroupCheckBox.Location = new System.Drawing.Point(161, 113);
+            this.tpeGroupCheckBox.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.tpeGroupCheckBox.Name = "tpeGroupCheckBox";
-            this.tpeGroupCheckBox.Size = new System.Drawing.Size(89, 27);
+            this.tpeGroupCheckBox.Size = new System.Drawing.Size(61, 19);
             this.tpeGroupCheckBox.TabIndex = 4;
             this.tpeGroupCheckBox.Text = "Group";
             this.toolTip1.SetToolTip(this.tpeGroupCheckBox, "If this and multivariate are True,\r\nthe multivariate TPE with the group decompose" +
@@ -1005,9 +1029,10 @@ namespace Tunny.UI
             // tpeMultivariateCheckBox
             // 
             this.tpeMultivariateCheckBox.AutoSize = true;
-            this.tpeMultivariateCheckBox.Location = new System.Drawing.Point(242, 136);
+            this.tpeMultivariateCheckBox.Location = new System.Drawing.Point(161, 91);
+            this.tpeMultivariateCheckBox.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.tpeMultivariateCheckBox.Name = "tpeMultivariateCheckBox";
-            this.tpeMultivariateCheckBox.Size = new System.Drawing.Size(138, 27);
+            this.tpeMultivariateCheckBox.Size = new System.Drawing.Size(95, 19);
             this.tpeMultivariateCheckBox.TabIndex = 3;
             this.tpeMultivariateCheckBox.Text = "Multivariate";
             this.toolTip1.SetToolTip(this.tpeMultivariateCheckBox, "If this is True, \r\nthe multivariate TPE is used when suggesting parameters. \r\nThe" +
@@ -1017,9 +1042,10 @@ namespace Tunny.UI
             // tpeConsiderEndpointsCheckBox
             // 
             this.tpeConsiderEndpointsCheckBox.AutoSize = true;
-            this.tpeConsiderEndpointsCheckBox.Location = new System.Drawing.Point(4, 170);
+            this.tpeConsiderEndpointsCheckBox.Location = new System.Drawing.Point(3, 113);
+            this.tpeConsiderEndpointsCheckBox.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.tpeConsiderEndpointsCheckBox.Name = "tpeConsiderEndpointsCheckBox";
-            this.tpeConsiderEndpointsCheckBox.Size = new System.Drawing.Size(205, 27);
+            this.tpeConsiderEndpointsCheckBox.Size = new System.Drawing.Size(136, 19);
             this.tpeConsiderEndpointsCheckBox.TabIndex = 2;
             this.tpeConsiderEndpointsCheckBox.Text = "Consider Endpoints";
             this.toolTip1.SetToolTip(this.tpeConsiderEndpointsCheckBox, "Take endpoints of domains into account\r\nwhen calculating variances of Gaussians i" +
@@ -1031,9 +1057,10 @@ namespace Tunny.UI
             this.tpeConsiderMagicClipCheckBox.AutoSize = true;
             this.tpeConsiderMagicClipCheckBox.Checked = true;
             this.tpeConsiderMagicClipCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.tpeConsiderMagicClipCheckBox.Location = new System.Drawing.Point(4, 202);
+            this.tpeConsiderMagicClipCheckBox.Location = new System.Drawing.Point(3, 135);
+            this.tpeConsiderMagicClipCheckBox.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.tpeConsiderMagicClipCheckBox.Name = "tpeConsiderMagicClipCheckBox";
-            this.tpeConsiderMagicClipCheckBox.Size = new System.Drawing.Size(207, 27);
+            this.tpeConsiderMagicClipCheckBox.Size = new System.Drawing.Size(138, 19);
             this.tpeConsiderMagicClipCheckBox.TabIndex = 1;
             this.tpeConsiderMagicClipCheckBox.Text = "Consider Magic Clip";
             this.toolTip1.SetToolTip(this.tpeConsiderMagicClipCheckBox, "Enable a heuristic to limit the smallest variances of Gaussians used in the Parze" +
@@ -1045,9 +1072,10 @@ namespace Tunny.UI
             this.tpeConsiderPriorCheckBox.AutoSize = true;
             this.tpeConsiderPriorCheckBox.Checked = true;
             this.tpeConsiderPriorCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.tpeConsiderPriorCheckBox.Location = new System.Drawing.Point(4, 136);
+            this.tpeConsiderPriorCheckBox.Location = new System.Drawing.Point(3, 91);
+            this.tpeConsiderPriorCheckBox.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.tpeConsiderPriorCheckBox.Name = "tpeConsiderPriorCheckBox";
-            this.tpeConsiderPriorCheckBox.Size = new System.Drawing.Size(159, 27);
+            this.tpeConsiderPriorCheckBox.Size = new System.Drawing.Size(107, 19);
             this.tpeConsiderPriorCheckBox.TabIndex = 0;
             this.tpeConsiderPriorCheckBox.Text = "Consider Prior";
             this.toolTip1.SetToolTip(this.tpeConsiderPriorCheckBox, "Enhance the stability of Parzen estimator by imposing a Gaussian prior when True." +
@@ -1060,19 +1088,21 @@ namespace Tunny.UI
             this.tabPage1.Controls.Add(this.gpDeterministicObjectiveCheckBox);
             this.tabPage1.Controls.Add(this.gpNStartupTrialsLabel);
             this.tabPage1.Controls.Add(this.gpStartupNumUpDown);
-            this.tabPage1.Location = new System.Drawing.Point(4, 32);
+            this.tabPage1.Location = new System.Drawing.Point(4, 24);
+            this.tabPage1.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.tabPage1.Name = "tabPage1";
-            this.tabPage1.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage1.Size = new System.Drawing.Size(412, 393);
+            this.tabPage1.Padding = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.tabPage1.Size = new System.Drawing.Size(272, 258);
             this.tabPage1.TabIndex = 7;
             this.tabPage1.Text = "GP(Optuna)";
             this.tabPage1.UseVisualStyleBackColor = true;
             // 
             // gpDefaultButton
             // 
-            this.gpDefaultButton.Location = new System.Drawing.Point(300, 350);
+            this.gpDefaultButton.Location = new System.Drawing.Point(200, 233);
+            this.gpDefaultButton.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.gpDefaultButton.Name = "gpDefaultButton";
-            this.gpDefaultButton.Size = new System.Drawing.Size(100, 38);
+            this.gpDefaultButton.Size = new System.Drawing.Size(67, 25);
             this.gpDefaultButton.TabIndex = 24;
             this.gpDefaultButton.Text = "Default";
             this.toolTip1.SetToolTip(this.gpDefaultButton, "Set to Optuna\'s default value.");
@@ -1082,9 +1112,10 @@ namespace Tunny.UI
             // gpDeterministicObjectiveCheckBox
             // 
             this.gpDeterministicObjectiveCheckBox.AutoSize = true;
-            this.gpDeterministicObjectiveCheckBox.Location = new System.Drawing.Point(10, 44);
+            this.gpDeterministicObjectiveCheckBox.Location = new System.Drawing.Point(7, 29);
+            this.gpDeterministicObjectiveCheckBox.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.gpDeterministicObjectiveCheckBox.Name = "gpDeterministicObjectiveCheckBox";
-            this.gpDeterministicObjectiveCheckBox.Size = new System.Drawing.Size(239, 27);
+            this.gpDeterministicObjectiveCheckBox.Size = new System.Drawing.Size(163, 19);
             this.gpDeterministicObjectiveCheckBox.TabIndex = 23;
             this.gpDeterministicObjectiveCheckBox.Text = "Deterministic Objective";
             this.toolTip1.SetToolTip(this.gpDeterministicObjectiveCheckBox, resources.GetString("gpDeterministicObjectiveCheckBox.ToolTip"));
@@ -1093,9 +1124,10 @@ namespace Tunny.UI
             // gpNStartupTrialsLabel
             // 
             this.gpNStartupTrialsLabel.AutoSize = true;
-            this.gpNStartupTrialsLabel.Location = new System.Drawing.Point(6, 8);
+            this.gpNStartupTrialsLabel.Location = new System.Drawing.Point(4, 5);
+            this.gpNStartupTrialsLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.gpNStartupTrialsLabel.Name = "gpNStartupTrialsLabel";
-            this.gpNStartupTrialsLabel.Size = new System.Drawing.Size(219, 23);
+            this.gpNStartupTrialsLabel.Size = new System.Drawing.Size(148, 15);
             this.gpNStartupTrialsLabel.TabIndex = 15;
             this.gpNStartupTrialsLabel.Text = "Number of startup trials";
             this.toolTip1.SetToolTip(this.gpNStartupTrialsLabel, "Number of initial trials, that is the number of trials to resort to independent s" +
@@ -1103,7 +1135,8 @@ namespace Tunny.UI
             // 
             // gpStartupNumUpDown
             // 
-            this.gpStartupNumUpDown.Location = new System.Drawing.Point(306, 8);
+            this.gpStartupNumUpDown.Location = new System.Drawing.Point(204, 5);
+            this.gpStartupNumUpDown.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.gpStartupNumUpDown.Maximum = new decimal(new int[] {
             1000,
             0,
@@ -1115,7 +1148,7 @@ namespace Tunny.UI
             0,
             0});
             this.gpStartupNumUpDown.Name = "gpStartupNumUpDown";
-            this.gpStartupNumUpDown.Size = new System.Drawing.Size(94, 30);
+            this.gpStartupNumUpDown.Size = new System.Drawing.Size(63, 23);
             this.gpStartupNumUpDown.TabIndex = 14;
             this.gpStartupNumUpDown.Value = new decimal(new int[] {
             10,
@@ -1128,19 +1161,21 @@ namespace Tunny.UI
             this.GP.Controls.Add(this.boTorchDefaultButton);
             this.GP.Controls.Add(this.boTorchNStartupTrialsLabel);
             this.GP.Controls.Add(this.boTorchStartupNumUpDown);
-            this.GP.Location = new System.Drawing.Point(4, 32);
+            this.GP.Location = new System.Drawing.Point(4, 24);
+            this.GP.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.GP.Name = "GP";
-            this.GP.Padding = new System.Windows.Forms.Padding(3);
-            this.GP.Size = new System.Drawing.Size(412, 393);
+            this.GP.Padding = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.GP.Size = new System.Drawing.Size(272, 258);
             this.GP.TabIndex = 1;
             this.GP.Text = "GP(BoTorch)";
             this.GP.UseVisualStyleBackColor = true;
             // 
             // boTorchDefaultButton
             // 
-            this.boTorchDefaultButton.Location = new System.Drawing.Point(300, 350);
+            this.boTorchDefaultButton.Location = new System.Drawing.Point(200, 233);
+            this.boTorchDefaultButton.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.boTorchDefaultButton.Name = "boTorchDefaultButton";
-            this.boTorchDefaultButton.Size = new System.Drawing.Size(100, 38);
+            this.boTorchDefaultButton.Size = new System.Drawing.Size(67, 25);
             this.boTorchDefaultButton.TabIndex = 14;
             this.boTorchDefaultButton.Text = "Default";
             this.toolTip1.SetToolTip(this.boTorchDefaultButton, "Set to Optuna\'s default value.");
@@ -1150,9 +1185,10 @@ namespace Tunny.UI
             // boTorchNStartupTrialsLabel
             // 
             this.boTorchNStartupTrialsLabel.AutoSize = true;
-            this.boTorchNStartupTrialsLabel.Location = new System.Drawing.Point(6, 8);
+            this.boTorchNStartupTrialsLabel.Location = new System.Drawing.Point(4, 5);
+            this.boTorchNStartupTrialsLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.boTorchNStartupTrialsLabel.Name = "boTorchNStartupTrialsLabel";
-            this.boTorchNStartupTrialsLabel.Size = new System.Drawing.Size(219, 23);
+            this.boTorchNStartupTrialsLabel.Size = new System.Drawing.Size(148, 15);
             this.boTorchNStartupTrialsLabel.TabIndex = 13;
             this.boTorchNStartupTrialsLabel.Text = "Number of startup trials";
             this.toolTip1.SetToolTip(this.boTorchNStartupTrialsLabel, "Number of initial trials, that is the number of trials to resort to independent s" +
@@ -1160,7 +1196,8 @@ namespace Tunny.UI
             // 
             // boTorchStartupNumUpDown
             // 
-            this.boTorchStartupNumUpDown.Location = new System.Drawing.Point(306, 8);
+            this.boTorchStartupNumUpDown.Location = new System.Drawing.Point(204, 5);
+            this.boTorchStartupNumUpDown.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.boTorchStartupNumUpDown.Maximum = new decimal(new int[] {
             1000,
             0,
@@ -1172,7 +1209,7 @@ namespace Tunny.UI
             0,
             0});
             this.boTorchStartupNumUpDown.Name = "boTorchStartupNumUpDown";
-            this.boTorchStartupNumUpDown.Size = new System.Drawing.Size(94, 30);
+            this.boTorchStartupNumUpDown.Size = new System.Drawing.Size(63, 23);
             this.boTorchStartupNumUpDown.TabIndex = 12;
             this.boTorchStartupNumUpDown.Value = new decimal(new int[] {
             10,
@@ -1193,9 +1230,10 @@ namespace Tunny.UI
             this.NSGAII.Controls.Add(this.nsga2CrossoverProbLabel);
             this.NSGAII.Controls.Add(this.nsga2CrossoverProbUpDown);
             this.NSGAII.Controls.Add(this.nsga2MutationProbUpDown);
-            this.NSGAII.Location = new System.Drawing.Point(4, 32);
+            this.NSGAII.Location = new System.Drawing.Point(4, 24);
+            this.NSGAII.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.NSGAII.Name = "NSGAII";
-            this.NSGAII.Size = new System.Drawing.Size(412, 393);
+            this.NSGAII.Size = new System.Drawing.Size(272, 258);
             this.NSGAII.TabIndex = 3;
             this.NSGAII.Text = "NSGAII";
             this.NSGAII.UseVisualStyleBackColor = true;
@@ -1211,19 +1249,20 @@ namespace Tunny.UI
             "SBX",
             "VSBX",
             "UNDX"});
-            this.nsga2CrossoverComboBox.Location = new System.Drawing.Point(266, 154);
-            this.nsga2CrossoverComboBox.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            this.nsga2CrossoverComboBox.Location = new System.Drawing.Point(177, 103);
+            this.nsga2CrossoverComboBox.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.nsga2CrossoverComboBox.Name = "nsga2CrossoverComboBox";
-            this.nsga2CrossoverComboBox.Size = new System.Drawing.Size(134, 31);
+            this.nsga2CrossoverComboBox.Size = new System.Drawing.Size(91, 23);
             this.nsga2CrossoverComboBox.TabIndex = 33;
             this.nsga2CrossoverComboBox.Text = "Uniform";
             // 
             // nsga2CrossoverCheckBox
             // 
             this.nsga2CrossoverCheckBox.AutoSize = true;
-            this.nsga2CrossoverCheckBox.Location = new System.Drawing.Point(14, 154);
+            this.nsga2CrossoverCheckBox.Location = new System.Drawing.Point(9, 103);
+            this.nsga2CrossoverCheckBox.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.nsga2CrossoverCheckBox.Name = "nsga2CrossoverCheckBox";
-            this.nsga2CrossoverCheckBox.Size = new System.Drawing.Size(122, 27);
+            this.nsga2CrossoverCheckBox.Size = new System.Drawing.Size(84, 19);
             this.nsga2CrossoverCheckBox.TabIndex = 24;
             this.nsga2CrossoverCheckBox.Text = "Crossover";
             this.toolTip1.SetToolTip(this.nsga2CrossoverCheckBox, "Crossover to be applied when creating child individuals. ");
@@ -1232,9 +1271,10 @@ namespace Tunny.UI
             // 
             // nsga2DefaultButton
             // 
-            this.nsga2DefaultButton.Location = new System.Drawing.Point(300, 350);
+            this.nsga2DefaultButton.Location = new System.Drawing.Point(200, 233);
+            this.nsga2DefaultButton.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.nsga2DefaultButton.Name = "nsga2DefaultButton";
-            this.nsga2DefaultButton.Size = new System.Drawing.Size(100, 38);
+            this.nsga2DefaultButton.Size = new System.Drawing.Size(67, 25);
             this.nsga2DefaultButton.TabIndex = 23;
             this.nsga2DefaultButton.Text = "Default";
             this.toolTip1.SetToolTip(this.nsga2DefaultButton, "Set to Optuna\'s default value.");
@@ -1244,9 +1284,10 @@ namespace Tunny.UI
             // nsga2MutationProbCheckBox
             // 
             this.nsga2MutationProbCheckBox.AutoSize = true;
-            this.nsga2MutationProbCheckBox.Location = new System.Drawing.Point(14, 8);
+            this.nsga2MutationProbCheckBox.Location = new System.Drawing.Point(9, 5);
+            this.nsga2MutationProbCheckBox.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.nsga2MutationProbCheckBox.Name = "nsga2MutationProbCheckBox";
-            this.nsga2MutationProbCheckBox.Size = new System.Drawing.Size(212, 27);
+            this.nsga2MutationProbCheckBox.Size = new System.Drawing.Size(142, 19);
             this.nsga2MutationProbCheckBox.TabIndex = 22;
             this.nsga2MutationProbCheckBox.Text = "Mutation Probability";
             this.toolTip1.SetToolTip(this.nsga2MutationProbCheckBox, "If False, \r\nthe solver automatically calculates mutation probability.");
@@ -1256,16 +1297,18 @@ namespace Tunny.UI
             // nsga2PopulationSizeLabel
             // 
             this.nsga2PopulationSizeLabel.AutoSize = true;
-            this.nsga2PopulationSizeLabel.Location = new System.Drawing.Point(9, 117);
+            this.nsga2PopulationSizeLabel.Location = new System.Drawing.Point(6, 78);
+            this.nsga2PopulationSizeLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.nsga2PopulationSizeLabel.Name = "nsga2PopulationSizeLabel";
-            this.nsga2PopulationSizeLabel.Size = new System.Drawing.Size(144, 23);
+            this.nsga2PopulationSizeLabel.Size = new System.Drawing.Size(95, 15);
             this.nsga2PopulationSizeLabel.TabIndex = 21;
             this.nsga2PopulationSizeLabel.Text = "Population Size";
             this.toolTip1.SetToolTip(this.nsga2PopulationSizeLabel, "Number of individuals (trials) in a generation.");
             // 
             // nsga2PopulationSizeUpDown
             // 
-            this.nsga2PopulationSizeUpDown.Location = new System.Drawing.Point(309, 116);
+            this.nsga2PopulationSizeUpDown.Location = new System.Drawing.Point(206, 77);
+            this.nsga2PopulationSizeUpDown.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.nsga2PopulationSizeUpDown.Maximum = new decimal(new int[] {
             1000,
             0,
@@ -1277,7 +1320,7 @@ namespace Tunny.UI
             0,
             0});
             this.nsga2PopulationSizeUpDown.Name = "nsga2PopulationSizeUpDown";
-            this.nsga2PopulationSizeUpDown.Size = new System.Drawing.Size(94, 30);
+            this.nsga2PopulationSizeUpDown.Size = new System.Drawing.Size(63, 23);
             this.nsga2PopulationSizeUpDown.TabIndex = 20;
             this.nsga2PopulationSizeUpDown.Value = new decimal(new int[] {
             50,
@@ -1288,9 +1331,10 @@ namespace Tunny.UI
             // nsga2SwappingProbLabel
             // 
             this.nsga2SwappingProbLabel.AutoSize = true;
-            this.nsga2SwappingProbLabel.Location = new System.Drawing.Point(9, 81);
+            this.nsga2SwappingProbLabel.Location = new System.Drawing.Point(6, 54);
+            this.nsga2SwappingProbLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.nsga2SwappingProbLabel.Name = "nsga2SwappingProbLabel";
-            this.nsga2SwappingProbLabel.Size = new System.Drawing.Size(194, 23);
+            this.nsga2SwappingProbLabel.Size = new System.Drawing.Size(128, 15);
             this.nsga2SwappingProbLabel.TabIndex = 19;
             this.nsga2SwappingProbLabel.Text = "Swapping Probability";
             this.toolTip1.SetToolTip(this.nsga2SwappingProbLabel, "Probability of swapping each parameter of the parents during crossover.");
@@ -1303,14 +1347,15 @@ namespace Tunny.UI
             0,
             0,
             131072});
-            this.nsga2SwappingProbUpDown.Location = new System.Drawing.Point(309, 80);
+            this.nsga2SwappingProbUpDown.Location = new System.Drawing.Point(206, 53);
+            this.nsga2SwappingProbUpDown.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.nsga2SwappingProbUpDown.Maximum = new decimal(new int[] {
             1,
             0,
             0,
             0});
             this.nsga2SwappingProbUpDown.Name = "nsga2SwappingProbUpDown";
-            this.nsga2SwappingProbUpDown.Size = new System.Drawing.Size(94, 30);
+            this.nsga2SwappingProbUpDown.Size = new System.Drawing.Size(63, 23);
             this.nsga2SwappingProbUpDown.TabIndex = 18;
             this.nsga2SwappingProbUpDown.Value = new decimal(new int[] {
             5,
@@ -1321,9 +1366,10 @@ namespace Tunny.UI
             // nsga2CrossoverProbLabel
             // 
             this.nsga2CrossoverProbLabel.AutoSize = true;
-            this.nsga2CrossoverProbLabel.Location = new System.Drawing.Point(9, 45);
+            this.nsga2CrossoverProbLabel.Location = new System.Drawing.Point(6, 30);
+            this.nsga2CrossoverProbLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.nsga2CrossoverProbLabel.Name = "nsga2CrossoverProbLabel";
-            this.nsga2CrossoverProbLabel.Size = new System.Drawing.Size(195, 23);
+            this.nsga2CrossoverProbLabel.Size = new System.Drawing.Size(130, 15);
             this.nsga2CrossoverProbLabel.TabIndex = 17;
             this.nsga2CrossoverProbLabel.Text = "Crossover Probability";
             this.toolTip1.SetToolTip(this.nsga2CrossoverProbLabel, "Probability that a crossover (parameters swapping between parents)\r\nwill occur wh" +
@@ -1337,14 +1383,15 @@ namespace Tunny.UI
             0,
             0,
             131072});
-            this.nsga2CrossoverProbUpDown.Location = new System.Drawing.Point(309, 44);
+            this.nsga2CrossoverProbUpDown.Location = new System.Drawing.Point(206, 29);
+            this.nsga2CrossoverProbUpDown.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.nsga2CrossoverProbUpDown.Maximum = new decimal(new int[] {
             1,
             0,
             0,
             0});
             this.nsga2CrossoverProbUpDown.Name = "nsga2CrossoverProbUpDown";
-            this.nsga2CrossoverProbUpDown.Size = new System.Drawing.Size(94, 30);
+            this.nsga2CrossoverProbUpDown.Size = new System.Drawing.Size(63, 23);
             this.nsga2CrossoverProbUpDown.TabIndex = 16;
             this.nsga2CrossoverProbUpDown.Value = new decimal(new int[] {
             9,
@@ -1361,14 +1408,15 @@ namespace Tunny.UI
             0,
             0,
             131072});
-            this.nsga2MutationProbUpDown.Location = new System.Drawing.Point(309, 8);
+            this.nsga2MutationProbUpDown.Location = new System.Drawing.Point(206, 5);
+            this.nsga2MutationProbUpDown.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.nsga2MutationProbUpDown.Maximum = new decimal(new int[] {
             1,
             0,
             0,
             0});
             this.nsga2MutationProbUpDown.Name = "nsga2MutationProbUpDown";
-            this.nsga2MutationProbUpDown.Size = new System.Drawing.Size(94, 30);
+            this.nsga2MutationProbUpDown.Size = new System.Drawing.Size(63, 23);
             this.nsga2MutationProbUpDown.TabIndex = 14;
             // 
             // NSGAIII
@@ -1384,11 +1432,10 @@ namespace Tunny.UI
             this.NSGAIII.Controls.Add(this.nsga3CrossoverProbLabel);
             this.NSGAIII.Controls.Add(this.nsga3CrossoverProbUpDown);
             this.NSGAIII.Controls.Add(this.nsga3MutationProbUpDown);
-            this.NSGAIII.Location = new System.Drawing.Point(4, 32);
-            this.NSGAIII.Margin = new System.Windows.Forms.Padding(4);
+            this.NSGAIII.Location = new System.Drawing.Point(4, 24);
             this.NSGAIII.Name = "NSGAIII";
-            this.NSGAIII.Padding = new System.Windows.Forms.Padding(4);
-            this.NSGAIII.Size = new System.Drawing.Size(412, 393);
+            this.NSGAIII.Padding = new System.Windows.Forms.Padding(3, 3, 3, 3);
+            this.NSGAIII.Size = new System.Drawing.Size(272, 258);
             this.NSGAIII.TabIndex = 6;
             this.NSGAIII.Text = "NSGAIII";
             this.NSGAIII.UseVisualStyleBackColor = true;
@@ -1404,19 +1451,20 @@ namespace Tunny.UI
             "SBX",
             "VSBX",
             "UNDX"});
-            this.nsga3CrossoverComboBox.Location = new System.Drawing.Point(264, 154);
-            this.nsga3CrossoverComboBox.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            this.nsga3CrossoverComboBox.Location = new System.Drawing.Point(176, 103);
+            this.nsga3CrossoverComboBox.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.nsga3CrossoverComboBox.Name = "nsga3CrossoverComboBox";
-            this.nsga3CrossoverComboBox.Size = new System.Drawing.Size(134, 31);
+            this.nsga3CrossoverComboBox.Size = new System.Drawing.Size(91, 23);
             this.nsga3CrossoverComboBox.TabIndex = 44;
             this.nsga3CrossoverComboBox.Text = "Uniform";
             // 
             // nsga3CrossoverCheckBox
             // 
             this.nsga3CrossoverCheckBox.AutoSize = true;
-            this.nsga3CrossoverCheckBox.Location = new System.Drawing.Point(12, 154);
+            this.nsga3CrossoverCheckBox.Location = new System.Drawing.Point(8, 103);
+            this.nsga3CrossoverCheckBox.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.nsga3CrossoverCheckBox.Name = "nsga3CrossoverCheckBox";
-            this.nsga3CrossoverCheckBox.Size = new System.Drawing.Size(122, 27);
+            this.nsga3CrossoverCheckBox.Size = new System.Drawing.Size(84, 19);
             this.nsga3CrossoverCheckBox.TabIndex = 43;
             this.nsga3CrossoverCheckBox.Text = "Crossover";
             this.toolTip1.SetToolTip(this.nsga3CrossoverCheckBox, "Crossover to be applied when creating child individuals. ");
@@ -1425,9 +1473,10 @@ namespace Tunny.UI
             // 
             // nsga3DefaultButton
             // 
-            this.nsga3DefaultButton.Location = new System.Drawing.Point(298, 348);
+            this.nsga3DefaultButton.Location = new System.Drawing.Point(199, 232);
+            this.nsga3DefaultButton.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.nsga3DefaultButton.Name = "nsga3DefaultButton";
-            this.nsga3DefaultButton.Size = new System.Drawing.Size(100, 39);
+            this.nsga3DefaultButton.Size = new System.Drawing.Size(67, 26);
             this.nsga3DefaultButton.TabIndex = 42;
             this.nsga3DefaultButton.Text = "Default";
             this.toolTip1.SetToolTip(this.nsga3DefaultButton, "Set to Optuna\'s default value.");
@@ -1437,9 +1486,10 @@ namespace Tunny.UI
             // nsga3MutationProbCheckBox
             // 
             this.nsga3MutationProbCheckBox.AutoSize = true;
-            this.nsga3MutationProbCheckBox.Location = new System.Drawing.Point(12, 6);
+            this.nsga3MutationProbCheckBox.Location = new System.Drawing.Point(8, 4);
+            this.nsga3MutationProbCheckBox.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.nsga3MutationProbCheckBox.Name = "nsga3MutationProbCheckBox";
-            this.nsga3MutationProbCheckBox.Size = new System.Drawing.Size(212, 27);
+            this.nsga3MutationProbCheckBox.Size = new System.Drawing.Size(142, 19);
             this.nsga3MutationProbCheckBox.TabIndex = 41;
             this.nsga3MutationProbCheckBox.Text = "Mutation Probability";
             this.toolTip1.SetToolTip(this.nsga3MutationProbCheckBox, "If False, \r\nthe solver automatically calculates mutation probability.");
@@ -1449,16 +1499,18 @@ namespace Tunny.UI
             // nsga3PopulationSizeLabel
             // 
             this.nsga3PopulationSizeLabel.AutoSize = true;
-            this.nsga3PopulationSizeLabel.Location = new System.Drawing.Point(8, 116);
+            this.nsga3PopulationSizeLabel.Location = new System.Drawing.Point(5, 77);
+            this.nsga3PopulationSizeLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.nsga3PopulationSizeLabel.Name = "nsga3PopulationSizeLabel";
-            this.nsga3PopulationSizeLabel.Size = new System.Drawing.Size(144, 23);
+            this.nsga3PopulationSizeLabel.Size = new System.Drawing.Size(95, 15);
             this.nsga3PopulationSizeLabel.TabIndex = 40;
             this.nsga3PopulationSizeLabel.Text = "Population Size";
             this.toolTip1.SetToolTip(this.nsga3PopulationSizeLabel, "Number of individuals (trials) in a generation.");
             // 
             // nsga3PopulationSizeUpDown
             // 
-            this.nsga3PopulationSizeUpDown.Location = new System.Drawing.Point(308, 114);
+            this.nsga3PopulationSizeUpDown.Location = new System.Drawing.Point(205, 76);
+            this.nsga3PopulationSizeUpDown.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.nsga3PopulationSizeUpDown.Maximum = new decimal(new int[] {
             1000,
             0,
@@ -1470,7 +1522,7 @@ namespace Tunny.UI
             0,
             0});
             this.nsga3PopulationSizeUpDown.Name = "nsga3PopulationSizeUpDown";
-            this.nsga3PopulationSizeUpDown.Size = new System.Drawing.Size(94, 30);
+            this.nsga3PopulationSizeUpDown.Size = new System.Drawing.Size(63, 23);
             this.nsga3PopulationSizeUpDown.TabIndex = 39;
             this.nsga3PopulationSizeUpDown.Value = new decimal(new int[] {
             50,
@@ -1481,9 +1533,10 @@ namespace Tunny.UI
             // nsga3SwappingProbLabel
             // 
             this.nsga3SwappingProbLabel.AutoSize = true;
-            this.nsga3SwappingProbLabel.Location = new System.Drawing.Point(8, 80);
+            this.nsga3SwappingProbLabel.Location = new System.Drawing.Point(5, 53);
+            this.nsga3SwappingProbLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.nsga3SwappingProbLabel.Name = "nsga3SwappingProbLabel";
-            this.nsga3SwappingProbLabel.Size = new System.Drawing.Size(194, 23);
+            this.nsga3SwappingProbLabel.Size = new System.Drawing.Size(128, 15);
             this.nsga3SwappingProbLabel.TabIndex = 38;
             this.nsga3SwappingProbLabel.Text = "Swapping Probability";
             this.toolTip1.SetToolTip(this.nsga3SwappingProbLabel, "Probability of swapping each parameter of the parents during crossover.");
@@ -1496,14 +1549,15 @@ namespace Tunny.UI
             0,
             0,
             131072});
-            this.nsga3SwappingProbUpDown.Location = new System.Drawing.Point(308, 78);
+            this.nsga3SwappingProbUpDown.Location = new System.Drawing.Point(205, 52);
+            this.nsga3SwappingProbUpDown.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.nsga3SwappingProbUpDown.Maximum = new decimal(new int[] {
             1,
             0,
             0,
             0});
             this.nsga3SwappingProbUpDown.Name = "nsga3SwappingProbUpDown";
-            this.nsga3SwappingProbUpDown.Size = new System.Drawing.Size(94, 30);
+            this.nsga3SwappingProbUpDown.Size = new System.Drawing.Size(63, 23);
             this.nsga3SwappingProbUpDown.TabIndex = 37;
             this.nsga3SwappingProbUpDown.Value = new decimal(new int[] {
             5,
@@ -1514,9 +1568,10 @@ namespace Tunny.UI
             // nsga3CrossoverProbLabel
             // 
             this.nsga3CrossoverProbLabel.AutoSize = true;
-            this.nsga3CrossoverProbLabel.Location = new System.Drawing.Point(8, 44);
+            this.nsga3CrossoverProbLabel.Location = new System.Drawing.Point(5, 29);
+            this.nsga3CrossoverProbLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.nsga3CrossoverProbLabel.Name = "nsga3CrossoverProbLabel";
-            this.nsga3CrossoverProbLabel.Size = new System.Drawing.Size(195, 23);
+            this.nsga3CrossoverProbLabel.Size = new System.Drawing.Size(130, 15);
             this.nsga3CrossoverProbLabel.TabIndex = 36;
             this.nsga3CrossoverProbLabel.Text = "Crossover Probability";
             this.toolTip1.SetToolTip(this.nsga3CrossoverProbLabel, "Probability that a crossover (parameters swapping between parents)\r\nwill occur wh" +
@@ -1530,14 +1585,15 @@ namespace Tunny.UI
             0,
             0,
             131072});
-            this.nsga3CrossoverProbUpDown.Location = new System.Drawing.Point(308, 42);
+            this.nsga3CrossoverProbUpDown.Location = new System.Drawing.Point(205, 28);
+            this.nsga3CrossoverProbUpDown.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.nsga3CrossoverProbUpDown.Maximum = new decimal(new int[] {
             1,
             0,
             0,
             0});
             this.nsga3CrossoverProbUpDown.Name = "nsga3CrossoverProbUpDown";
-            this.nsga3CrossoverProbUpDown.Size = new System.Drawing.Size(94, 30);
+            this.nsga3CrossoverProbUpDown.Size = new System.Drawing.Size(63, 23);
             this.nsga3CrossoverProbUpDown.TabIndex = 35;
             this.nsga3CrossoverProbUpDown.Value = new decimal(new int[] {
             9,
@@ -1554,14 +1610,15 @@ namespace Tunny.UI
             0,
             0,
             131072});
-            this.nsga3MutationProbUpDown.Location = new System.Drawing.Point(308, 6);
+            this.nsga3MutationProbUpDown.Location = new System.Drawing.Point(205, 4);
+            this.nsga3MutationProbUpDown.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.nsga3MutationProbUpDown.Maximum = new decimal(new int[] {
             1,
             0,
             0,
             0});
             this.nsga3MutationProbUpDown.Name = "nsga3MutationProbUpDown";
-            this.nsga3MutationProbUpDown.Size = new System.Drawing.Size(94, 30);
+            this.nsga3MutationProbUpDown.Size = new System.Drawing.Size(63, 23);
             this.nsga3MutationProbUpDown.TabIndex = 34;
             // 
             // CMAES
@@ -1583,9 +1640,10 @@ namespace Tunny.UI
             this.CMAES.Controls.Add(this.cmaEsIncPopSizeUpDown);
             this.CMAES.Controls.Add(this.cmaEsSigmaCheckBox);
             this.CMAES.Controls.Add(this.cmaEsSigmaNumUpDown);
-            this.CMAES.Location = new System.Drawing.Point(4, 32);
+            this.CMAES.Location = new System.Drawing.Point(4, 24);
+            this.CMAES.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.CMAES.Name = "CMAES";
-            this.CMAES.Size = new System.Drawing.Size(412, 393);
+            this.CMAES.Size = new System.Drawing.Size(272, 258);
             this.CMAES.TabIndex = 2;
             this.CMAES.Text = "CMA-ES";
             this.CMAES.UseVisualStyleBackColor = true;
@@ -1593,10 +1651,9 @@ namespace Tunny.UI
             // cmaEsUseFirstEggToX0CheckBox
             // 
             this.cmaEsUseFirstEggToX0CheckBox.AutoSize = true;
-            this.cmaEsUseFirstEggToX0CheckBox.Location = new System.Drawing.Point(10, 278);
-            this.cmaEsUseFirstEggToX0CheckBox.Margin = new System.Windows.Forms.Padding(4);
+            this.cmaEsUseFirstEggToX0CheckBox.Location = new System.Drawing.Point(7, 185);
             this.cmaEsUseFirstEggToX0CheckBox.Name = "cmaEsUseFirstEggToX0CheckBox";
-            this.cmaEsUseFirstEggToX0CheckBox.Size = new System.Drawing.Size(235, 27);
+            this.cmaEsUseFirstEggToX0CheckBox.Size = new System.Drawing.Size(158, 19);
             this.cmaEsUseFirstEggToX0CheckBox.TabIndex = 39;
             this.cmaEsUseFirstEggToX0CheckBox.Text = "Use first FishEgg to X0";
             this.toolTip1.SetToolTip(this.cmaEsUseFirstEggToX0CheckBox, "If this is True, \r\nthe initial value of FishEgg be the mean value X0 assumed for " +
@@ -1608,10 +1665,9 @@ namespace Tunny.UI
             this.cmaEsWithMarginCheckBox.AutoSize = true;
             this.cmaEsWithMarginCheckBox.Checked = true;
             this.cmaEsWithMarginCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.cmaEsWithMarginCheckBox.Location = new System.Drawing.Point(260, 75);
-            this.cmaEsWithMarginCheckBox.Margin = new System.Windows.Forms.Padding(4);
+            this.cmaEsWithMarginCheckBox.Location = new System.Drawing.Point(173, 50);
             this.cmaEsWithMarginCheckBox.Name = "cmaEsWithMarginCheckBox";
-            this.cmaEsWithMarginCheckBox.Size = new System.Drawing.Size(144, 27);
+            this.cmaEsWithMarginCheckBox.Size = new System.Drawing.Size(98, 19);
             this.cmaEsWithMarginCheckBox.TabIndex = 38;
             this.cmaEsWithMarginCheckBox.Text = "With margin";
             this.cmaEsWithMarginCheckBox.UseVisualStyleBackColor = true;
@@ -1621,19 +1677,19 @@ namespace Tunny.UI
             // 
             this.cmaEsWarmStartComboBox.Enabled = false;
             this.cmaEsWarmStartComboBox.FormattingEnabled = true;
-            this.cmaEsWarmStartComboBox.Location = new System.Drawing.Point(218, 237);
-            this.cmaEsWarmStartComboBox.Margin = new System.Windows.Forms.Padding(6);
+            this.cmaEsWarmStartComboBox.Location = new System.Drawing.Point(145, 158);
+            this.cmaEsWarmStartComboBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.cmaEsWarmStartComboBox.Name = "cmaEsWarmStartComboBox";
-            this.cmaEsWarmStartComboBox.Size = new System.Drawing.Size(180, 31);
+            this.cmaEsWarmStartComboBox.Size = new System.Drawing.Size(121, 23);
             this.cmaEsWarmStartComboBox.TabIndex = 37;
             // 
             // cmaEsWarmStartCmaEsCheckBox
             // 
             this.cmaEsWarmStartCmaEsCheckBox.AutoSize = true;
-            this.cmaEsWarmStartCmaEsCheckBox.Location = new System.Drawing.Point(12, 212);
-            this.cmaEsWarmStartCmaEsCheckBox.Margin = new System.Windows.Forms.Padding(6);
+            this.cmaEsWarmStartCmaEsCheckBox.Location = new System.Drawing.Point(8, 141);
+            this.cmaEsWarmStartCmaEsCheckBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.cmaEsWarmStartCmaEsCheckBox.Name = "cmaEsWarmStartCmaEsCheckBox";
-            this.cmaEsWarmStartCmaEsCheckBox.Size = new System.Drawing.Size(210, 27);
+            this.cmaEsWarmStartCmaEsCheckBox.Size = new System.Drawing.Size(145, 19);
             this.cmaEsWarmStartCmaEsCheckBox.TabIndex = 36;
             this.cmaEsWarmStartCmaEsCheckBox.Text = "Warm Start CMA-ES";
             this.cmaEsWarmStartCmaEsCheckBox.UseVisualStyleBackColor = true;
@@ -1642,15 +1698,14 @@ namespace Tunny.UI
             // cmaEsPopulationSizeUpDown
             // 
             this.cmaEsPopulationSizeUpDown.Enabled = false;
-            this.cmaEsPopulationSizeUpDown.Location = new System.Drawing.Point(303, 140);
-            this.cmaEsPopulationSizeUpDown.Margin = new System.Windows.Forms.Padding(4);
+            this.cmaEsPopulationSizeUpDown.Location = new System.Drawing.Point(202, 93);
             this.cmaEsPopulationSizeUpDown.Minimum = new decimal(new int[] {
             1,
             0,
             0,
             0});
             this.cmaEsPopulationSizeUpDown.Name = "cmaEsPopulationSizeUpDown";
-            this.cmaEsPopulationSizeUpDown.Size = new System.Drawing.Size(94, 30);
+            this.cmaEsPopulationSizeUpDown.Size = new System.Drawing.Size(63, 23);
             this.cmaEsPopulationSizeUpDown.TabIndex = 35;
             this.cmaEsPopulationSizeUpDown.Value = new decimal(new int[] {
             10,
@@ -1661,10 +1716,9 @@ namespace Tunny.UI
             // cmaEsPopulationSizeLabel
             // 
             this.cmaEsPopulationSizeLabel.AutoSize = true;
-            this.cmaEsPopulationSizeLabel.Location = new System.Drawing.Point(6, 146);
-            this.cmaEsPopulationSizeLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.cmaEsPopulationSizeLabel.Location = new System.Drawing.Point(4, 97);
             this.cmaEsPopulationSizeLabel.Name = "cmaEsPopulationSizeLabel";
-            this.cmaEsPopulationSizeLabel.Size = new System.Drawing.Size(144, 23);
+            this.cmaEsPopulationSizeLabel.Size = new System.Drawing.Size(95, 15);
             this.cmaEsPopulationSizeLabel.TabIndex = 34;
             this.cmaEsPopulationSizeLabel.Text = "Population Size";
             this.toolTip1.SetToolTip(this.cmaEsPopulationSizeLabel, "A population size of CMA-ES. \r\nWhen set restart_strategy is checked,\r\nthis is use" +
@@ -1672,9 +1726,10 @@ namespace Tunny.UI
             // 
             // cmaEsDefaultButton
             // 
-            this.cmaEsDefaultButton.Location = new System.Drawing.Point(300, 350);
+            this.cmaEsDefaultButton.Location = new System.Drawing.Point(200, 233);
+            this.cmaEsDefaultButton.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.cmaEsDefaultButton.Name = "cmaEsDefaultButton";
-            this.cmaEsDefaultButton.Size = new System.Drawing.Size(100, 38);
+            this.cmaEsDefaultButton.Size = new System.Drawing.Size(67, 25);
             this.cmaEsDefaultButton.TabIndex = 33;
             this.cmaEsDefaultButton.Text = "Default";
             this.toolTip1.SetToolTip(this.cmaEsDefaultButton, "Set to Optuna\'s default value.");
@@ -1684,10 +1739,9 @@ namespace Tunny.UI
             // cmaEsRestartCheckBox
             // 
             this.cmaEsRestartCheckBox.AutoSize = true;
-            this.cmaEsRestartCheckBox.Location = new System.Drawing.Point(10, 108);
-            this.cmaEsRestartCheckBox.Margin = new System.Windows.Forms.Padding(4);
+            this.cmaEsRestartCheckBox.Location = new System.Drawing.Point(7, 72);
             this.cmaEsRestartCheckBox.Name = "cmaEsRestartCheckBox";
-            this.cmaEsRestartCheckBox.Size = new System.Drawing.Size(171, 27);
+            this.cmaEsRestartCheckBox.Size = new System.Drawing.Size(120, 19);
             this.cmaEsRestartCheckBox.TabIndex = 32;
             this.cmaEsRestartCheckBox.Text = "RestartStrategy";
             this.toolTip1.SetToolTip(this.cmaEsRestartCheckBox, "If given False, \r\nCMA-ES will not restart.\r\nStrategy for restarting CMA-ES optimi" +
@@ -1699,10 +1753,9 @@ namespace Tunny.UI
             // 
             this.cmaEsUseSaparableCmaCheckBox.AutoSize = true;
             this.cmaEsUseSaparableCmaCheckBox.Enabled = false;
-            this.cmaEsUseSaparableCmaCheckBox.Location = new System.Drawing.Point(10, 74);
-            this.cmaEsUseSaparableCmaCheckBox.Margin = new System.Windows.Forms.Padding(4);
+            this.cmaEsUseSaparableCmaCheckBox.Location = new System.Drawing.Point(7, 49);
             this.cmaEsUseSaparableCmaCheckBox.Name = "cmaEsUseSaparableCmaCheckBox";
-            this.cmaEsUseSaparableCmaCheckBox.Size = new System.Drawing.Size(204, 27);
+            this.cmaEsUseSaparableCmaCheckBox.Size = new System.Drawing.Size(140, 19);
             this.cmaEsUseSaparableCmaCheckBox.TabIndex = 31;
             this.cmaEsUseSaparableCmaCheckBox.Text = "Use Separable CMA";
             this.toolTip1.SetToolTip(this.cmaEsUseSaparableCmaCheckBox, resources.GetString("cmaEsUseSaparableCmaCheckBox.ToolTip"));
@@ -1712,9 +1765,10 @@ namespace Tunny.UI
             // cmaEsNStartupTrialsLabel
             // 
             this.cmaEsNStartupTrialsLabel.AutoSize = true;
-            this.cmaEsNStartupTrialsLabel.Location = new System.Drawing.Point(8, 4);
+            this.cmaEsNStartupTrialsLabel.Location = new System.Drawing.Point(5, 3);
+            this.cmaEsNStartupTrialsLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.cmaEsNStartupTrialsLabel.Name = "cmaEsNStartupTrialsLabel";
-            this.cmaEsNStartupTrialsLabel.Size = new System.Drawing.Size(219, 23);
+            this.cmaEsNStartupTrialsLabel.Size = new System.Drawing.Size(148, 15);
             this.cmaEsNStartupTrialsLabel.TabIndex = 30;
             this.cmaEsNStartupTrialsLabel.Text = "Number of startup trials";
             this.toolTip1.SetToolTip(this.cmaEsNStartupTrialsLabel, "The independent sampling is used instead of the CMA-ES algorithm\r\nuntil the given" +
@@ -1722,7 +1776,8 @@ namespace Tunny.UI
             // 
             // cmaEsStartupNumUpDown
             // 
-            this.cmaEsStartupNumUpDown.Location = new System.Drawing.Point(309, 4);
+            this.cmaEsStartupNumUpDown.Location = new System.Drawing.Point(206, 3);
+            this.cmaEsStartupNumUpDown.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.cmaEsStartupNumUpDown.Maximum = new decimal(new int[] {
             1000,
             0,
@@ -1734,7 +1789,7 @@ namespace Tunny.UI
             0,
             0});
             this.cmaEsStartupNumUpDown.Name = "cmaEsStartupNumUpDown";
-            this.cmaEsStartupNumUpDown.Size = new System.Drawing.Size(94, 30);
+            this.cmaEsStartupNumUpDown.Size = new System.Drawing.Size(63, 23);
             this.cmaEsStartupNumUpDown.TabIndex = 29;
             this.cmaEsStartupNumUpDown.Value = new decimal(new int[] {
             1,
@@ -1746,10 +1801,9 @@ namespace Tunny.UI
             // 
             this.cmaEsConsiderPruneTrialsCheckBox.AutoSize = true;
             this.cmaEsConsiderPruneTrialsCheckBox.Enabled = false;
-            this.cmaEsConsiderPruneTrialsCheckBox.Location = new System.Drawing.Point(15, 536);
-            this.cmaEsConsiderPruneTrialsCheckBox.Margin = new System.Windows.Forms.Padding(4);
+            this.cmaEsConsiderPruneTrialsCheckBox.Location = new System.Drawing.Point(10, 357);
             this.cmaEsConsiderPruneTrialsCheckBox.Name = "cmaEsConsiderPruneTrialsCheckBox";
-            this.cmaEsConsiderPruneTrialsCheckBox.Size = new System.Drawing.Size(230, 27);
+            this.cmaEsConsiderPruneTrialsCheckBox.Size = new System.Drawing.Size(155, 19);
             this.cmaEsConsiderPruneTrialsCheckBox.TabIndex = 28;
             this.cmaEsConsiderPruneTrialsCheckBox.Text = "Consider Pruned Trials";
             this.toolTip1.SetToolTip(this.cmaEsConsiderPruneTrialsCheckBox, "If this is True, \r\nthe PRUNED trials are considered for sampling.");
@@ -1761,10 +1815,9 @@ namespace Tunny.UI
             this.cmaEsWarnIndependentSamplingCheckBox.Checked = true;
             this.cmaEsWarnIndependentSamplingCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
             this.cmaEsWarnIndependentSamplingCheckBox.Enabled = false;
-            this.cmaEsWarnIndependentSamplingCheckBox.Location = new System.Drawing.Point(10, 315);
-            this.cmaEsWarnIndependentSamplingCheckBox.Margin = new System.Windows.Forms.Padding(4);
+            this.cmaEsWarnIndependentSamplingCheckBox.Location = new System.Drawing.Point(7, 210);
             this.cmaEsWarnIndependentSamplingCheckBox.Name = "cmaEsWarnIndependentSamplingCheckBox";
-            this.cmaEsWarnIndependentSamplingCheckBox.Size = new System.Drawing.Size(284, 27);
+            this.cmaEsWarnIndependentSamplingCheckBox.Size = new System.Drawing.Size(191, 19);
             this.cmaEsWarnIndependentSamplingCheckBox.TabIndex = 27;
             this.cmaEsWarnIndependentSamplingCheckBox.Text = "Warn Independent Sampling";
             this.toolTip1.SetToolTip(this.cmaEsWarnIndependentSamplingCheckBox, "If this is True, \r\na warning message is emitted when the value of a parameter is " +
@@ -1774,10 +1827,9 @@ namespace Tunny.UI
             // cmaEsIncPopsizeLabel
             // 
             this.cmaEsIncPopsizeLabel.AutoSize = true;
-            this.cmaEsIncPopsizeLabel.Location = new System.Drawing.Point(6, 182);
-            this.cmaEsIncPopsizeLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.cmaEsIncPopsizeLabel.Location = new System.Drawing.Point(4, 121);
             this.cmaEsIncPopsizeLabel.Name = "cmaEsIncPopsizeLabel";
-            this.cmaEsIncPopsizeLabel.Size = new System.Drawing.Size(240, 23);
+            this.cmaEsIncPopsizeLabel.Size = new System.Drawing.Size(159, 15);
             this.cmaEsIncPopsizeLabel.TabIndex = 26;
             this.cmaEsIncPopsizeLabel.Text = "Increasing Population Size";
             this.toolTip1.SetToolTip(this.cmaEsIncPopsizeLabel, "Multiplier for increasing population size before each restart.");
@@ -1785,15 +1837,14 @@ namespace Tunny.UI
             // cmaEsIncPopSizeUpDown
             // 
             this.cmaEsIncPopSizeUpDown.Enabled = false;
-            this.cmaEsIncPopSizeUpDown.Location = new System.Drawing.Point(303, 182);
-            this.cmaEsIncPopSizeUpDown.Margin = new System.Windows.Forms.Padding(4);
+            this.cmaEsIncPopSizeUpDown.Location = new System.Drawing.Point(202, 121);
             this.cmaEsIncPopSizeUpDown.Minimum = new decimal(new int[] {
             1,
             0,
             0,
             0});
             this.cmaEsIncPopSizeUpDown.Name = "cmaEsIncPopSizeUpDown";
-            this.cmaEsIncPopSizeUpDown.Size = new System.Drawing.Size(94, 30);
+            this.cmaEsIncPopSizeUpDown.Size = new System.Drawing.Size(63, 23);
             this.cmaEsIncPopSizeUpDown.TabIndex = 25;
             this.cmaEsIncPopSizeUpDown.Value = new decimal(new int[] {
             2,
@@ -1804,9 +1855,10 @@ namespace Tunny.UI
             // cmaEsSigmaCheckBox
             // 
             this.cmaEsSigmaCheckBox.AutoSize = true;
-            this.cmaEsSigmaCheckBox.Location = new System.Drawing.Point(10, 39);
+            this.cmaEsSigmaCheckBox.Location = new System.Drawing.Point(7, 26);
+            this.cmaEsSigmaCheckBox.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.cmaEsSigmaCheckBox.Name = "cmaEsSigmaCheckBox";
-            this.cmaEsSigmaCheckBox.Size = new System.Drawing.Size(101, 27);
+            this.cmaEsSigmaCheckBox.Size = new System.Drawing.Size(70, 19);
             this.cmaEsSigmaCheckBox.TabIndex = 24;
             this.cmaEsSigmaCheckBox.Text = "Sigma0";
             this.toolTip1.SetToolTip(this.cmaEsSigmaCheckBox, "Initial standard deviation of CMA-ES. By default, sigma0 is set to min_range / 6," +
@@ -1824,9 +1876,10 @@ namespace Tunny.UI
             0,
             0,
             131072});
-            this.cmaEsSigmaNumUpDown.Location = new System.Drawing.Point(309, 38);
+            this.cmaEsSigmaNumUpDown.Location = new System.Drawing.Point(206, 25);
+            this.cmaEsSigmaNumUpDown.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.cmaEsSigmaNumUpDown.Name = "cmaEsSigmaNumUpDown";
-            this.cmaEsSigmaNumUpDown.Size = new System.Drawing.Size(94, 30);
+            this.cmaEsSigmaNumUpDown.Size = new System.Drawing.Size(63, 23);
             this.cmaEsSigmaNumUpDown.TabIndex = 23;
             // 
             // QMC
@@ -1837,18 +1890,20 @@ namespace Tunny.UI
             this.QMC.Controls.Add(this.qmcWarnAsyncSeedingCheckBox);
             this.QMC.Controls.Add(this.qmcScrambleCheckBox);
             this.QMC.Controls.Add(this.qmcWarnIndependentSamplingCheckBox);
-            this.QMC.Location = new System.Drawing.Point(4, 32);
+            this.QMC.Location = new System.Drawing.Point(4, 24);
+            this.QMC.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.QMC.Name = "QMC";
-            this.QMC.Size = new System.Drawing.Size(412, 393);
+            this.QMC.Size = new System.Drawing.Size(272, 258);
             this.QMC.TabIndex = 4;
             this.QMC.Text = "QMC";
             this.QMC.UseVisualStyleBackColor = true;
             // 
             // qmcDefaultButton
             // 
-            this.qmcDefaultButton.Location = new System.Drawing.Point(300, 350);
+            this.qmcDefaultButton.Location = new System.Drawing.Point(200, 233);
+            this.qmcDefaultButton.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.qmcDefaultButton.Name = "qmcDefaultButton";
-            this.qmcDefaultButton.Size = new System.Drawing.Size(100, 38);
+            this.qmcDefaultButton.Size = new System.Drawing.Size(67, 25);
             this.qmcDefaultButton.TabIndex = 33;
             this.qmcDefaultButton.Text = "Default";
             this.toolTip1.SetToolTip(this.qmcDefaultButton, "Set to Optuna\'s default value.");
@@ -1861,19 +1916,20 @@ namespace Tunny.UI
             this.qmcTypeComboBox.Items.AddRange(new object[] {
             "sobol",
             "halton"});
-            this.qmcTypeComboBox.Location = new System.Drawing.Point(267, 10);
-            this.qmcTypeComboBox.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            this.qmcTypeComboBox.Location = new System.Drawing.Point(178, 7);
+            this.qmcTypeComboBox.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.qmcTypeComboBox.Name = "qmcTypeComboBox";
-            this.qmcTypeComboBox.Size = new System.Drawing.Size(134, 31);
+            this.qmcTypeComboBox.Size = new System.Drawing.Size(91, 23);
             this.qmcTypeComboBox.TabIndex = 32;
             this.qmcTypeComboBox.Text = "sobol";
             // 
             // qmcTypeLabel
             // 
             this.qmcTypeLabel.AutoSize = true;
-            this.qmcTypeLabel.Location = new System.Drawing.Point(3, 14);
+            this.qmcTypeLabel.Location = new System.Drawing.Point(2, 9);
+            this.qmcTypeLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.qmcTypeLabel.Name = "qmcTypeLabel";
-            this.qmcTypeLabel.Size = new System.Drawing.Size(97, 23);
+            this.qmcTypeLabel.Size = new System.Drawing.Size(66, 15);
             this.qmcTypeLabel.TabIndex = 31;
             this.qmcTypeLabel.Text = "QMC Type";
             this.toolTip1.SetToolTip(this.qmcTypeLabel, "The type of QMC sequence to be sampled.\r\n");
@@ -1884,9 +1940,10 @@ namespace Tunny.UI
             this.qmcWarnAsyncSeedingCheckBox.Checked = true;
             this.qmcWarnAsyncSeedingCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
             this.qmcWarnAsyncSeedingCheckBox.Enabled = false;
-            this.qmcWarnAsyncSeedingCheckBox.Location = new System.Drawing.Point(8, 122);
+            this.qmcWarnAsyncSeedingCheckBox.Location = new System.Drawing.Point(5, 81);
+            this.qmcWarnAsyncSeedingCheckBox.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.qmcWarnAsyncSeedingCheckBox.Name = "qmcWarnAsyncSeedingCheckBox";
-            this.qmcWarnAsyncSeedingCheckBox.Size = new System.Drawing.Size(284, 27);
+            this.qmcWarnAsyncSeedingCheckBox.Size = new System.Drawing.Size(190, 19);
             this.qmcWarnAsyncSeedingCheckBox.TabIndex = 30;
             this.qmcWarnAsyncSeedingCheckBox.Text = "Warn Asynchronous Seeding";
             this.toolTip1.SetToolTip(this.qmcWarnAsyncSeedingCheckBox, "If this is True, \r\na warning message is emitted \r\nwhen the scrambling (randomizat" +
@@ -1897,9 +1954,10 @@ namespace Tunny.UI
             // qmcScrambleCheckBox
             // 
             this.qmcScrambleCheckBox.AutoSize = true;
-            this.qmcScrambleCheckBox.Location = new System.Drawing.Point(8, 56);
+            this.qmcScrambleCheckBox.Location = new System.Drawing.Point(5, 37);
+            this.qmcScrambleCheckBox.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.qmcScrambleCheckBox.Name = "qmcScrambleCheckBox";
-            this.qmcScrambleCheckBox.Size = new System.Drawing.Size(116, 27);
+            this.qmcScrambleCheckBox.Size = new System.Drawing.Size(81, 19);
             this.qmcScrambleCheckBox.TabIndex = 29;
             this.qmcScrambleCheckBox.Text = "Scramble";
             this.toolTip1.SetToolTip(this.qmcScrambleCheckBox, "If this option is True, \r\nscrambling (randomization) is applied to the QMC sequen" +
@@ -1912,9 +1970,10 @@ namespace Tunny.UI
             this.qmcWarnIndependentSamplingCheckBox.Checked = true;
             this.qmcWarnIndependentSamplingCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
             this.qmcWarnIndependentSamplingCheckBox.Enabled = false;
-            this.qmcWarnIndependentSamplingCheckBox.Location = new System.Drawing.Point(8, 88);
+            this.qmcWarnIndependentSamplingCheckBox.Location = new System.Drawing.Point(5, 59);
+            this.qmcWarnIndependentSamplingCheckBox.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.qmcWarnIndependentSamplingCheckBox.Name = "qmcWarnIndependentSamplingCheckBox";
-            this.qmcWarnIndependentSamplingCheckBox.Size = new System.Drawing.Size(284, 27);
+            this.qmcWarnIndependentSamplingCheckBox.Size = new System.Drawing.Size(191, 19);
             this.qmcWarnIndependentSamplingCheckBox.TabIndex = 28;
             this.qmcWarnIndependentSamplingCheckBox.Text = "Warn Independent Sampling";
             this.toolTip1.SetToolTip(this.qmcWarnIndependentSamplingCheckBox, "If this is True, \r\na warning message is emitted when the value of a parameter\r\nis" +
@@ -1930,10 +1989,11 @@ namespace Tunny.UI
             this.Misc.Controls.Add(this.miscDefaultButton);
             this.Misc.Controls.Add(this.runGarbageCollectionComboBox);
             this.Misc.Controls.Add(this.runGarbageCollectionLabel);
-            this.Misc.Location = new System.Drawing.Point(4, 32);
+            this.Misc.Location = new System.Drawing.Point(4, 24);
+            this.Misc.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.Misc.Name = "Misc";
-            this.Misc.Padding = new System.Windows.Forms.Padding(3);
-            this.Misc.Size = new System.Drawing.Size(412, 393);
+            this.Misc.Padding = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.Misc.Size = new System.Drawing.Size(272, 258);
             this.Misc.TabIndex = 5;
             this.Misc.Text = "Misc";
             this.Misc.UseVisualStyleBackColor = true;
@@ -1941,9 +2001,10 @@ namespace Tunny.UI
             // ignoreDuplicateSamplingCheckBox
             // 
             this.ignoreDuplicateSamplingCheckBox.AutoSize = true;
-            this.ignoreDuplicateSamplingCheckBox.Location = new System.Drawing.Point(10, 141);
+            this.ignoreDuplicateSamplingCheckBox.Location = new System.Drawing.Point(7, 94);
+            this.ignoreDuplicateSamplingCheckBox.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.ignoreDuplicateSamplingCheckBox.Name = "ignoreDuplicateSamplingCheckBox";
-            this.ignoreDuplicateSamplingCheckBox.Size = new System.Drawing.Size(263, 27);
+            this.ignoreDuplicateSamplingCheckBox.Size = new System.Drawing.Size(176, 19);
             this.ignoreDuplicateSamplingCheckBox.TabIndex = 40;
             this.ignoreDuplicateSamplingCheckBox.Text = "Ignore duplicate sampling";
             this.ignoreDuplicateSamplingCheckBox.UseVisualStyleBackColor = true;
@@ -1956,10 +2017,10 @@ namespace Tunny.UI
             "Verbose",
             "Debug",
             "Info"});
-            this.miscLogComboBox.Location = new System.Drawing.Point(236, 56);
-            this.miscLogComboBox.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            this.miscLogComboBox.Location = new System.Drawing.Point(157, 37);
+            this.miscLogComboBox.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.miscLogComboBox.Name = "miscLogComboBox";
-            this.miscLogComboBox.Size = new System.Drawing.Size(169, 31);
+            this.miscLogComboBox.Size = new System.Drawing.Size(114, 23);
             this.miscLogComboBox.TabIndex = 39;
             this.miscLogComboBox.Text = "Info";
             this.miscLogComboBox.SelectedIndexChanged += new System.EventHandler(this.MiscLogComboBox_SelectedIndexChanged);
@@ -1967,9 +2028,10 @@ namespace Tunny.UI
             // miscLogLevelLabel
             // 
             this.miscLogLevelLabel.AutoSize = true;
-            this.miscLogLevelLabel.Location = new System.Drawing.Point(6, 60);
+            this.miscLogLevelLabel.Location = new System.Drawing.Point(4, 40);
+            this.miscLogLevelLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.miscLogLevelLabel.Name = "miscLogLevelLabel";
-            this.miscLogLevelLabel.Size = new System.Drawing.Size(88, 23);
+            this.miscLogLevelLabel.Size = new System.Drawing.Size(59, 15);
             this.miscLogLevelLabel.TabIndex = 38;
             this.miscLogLevelLabel.Text = "Log level";
             this.toolTip1.SetToolTip(this.miscLogLevelLabel, "Setting output log level. verbose has most information.");
@@ -1977,18 +2039,20 @@ namespace Tunny.UI
             // checkPythonLibrariesCheckBox
             // 
             this.checkPythonLibrariesCheckBox.AutoSize = true;
-            this.checkPythonLibrariesCheckBox.Location = new System.Drawing.Point(10, 106);
+            this.checkPythonLibrariesCheckBox.Location = new System.Drawing.Point(7, 71);
+            this.checkPythonLibrariesCheckBox.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.checkPythonLibrariesCheckBox.Name = "checkPythonLibrariesCheckBox";
-            this.checkPythonLibrariesCheckBox.Size = new System.Drawing.Size(377, 27);
+            this.checkPythonLibrariesCheckBox.Size = new System.Drawing.Size(252, 19);
             this.checkPythonLibrariesCheckBox.TabIndex = 37;
             this.checkPythonLibrariesCheckBox.Text = "Run Python installer at window startup";
             this.checkPythonLibrariesCheckBox.UseVisualStyleBackColor = true;
             // 
             // miscDefaultButton
             // 
-            this.miscDefaultButton.Location = new System.Drawing.Point(300, 350);
+            this.miscDefaultButton.Location = new System.Drawing.Point(200, 233);
+            this.miscDefaultButton.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.miscDefaultButton.Name = "miscDefaultButton";
-            this.miscDefaultButton.Size = new System.Drawing.Size(100, 38);
+            this.miscDefaultButton.Size = new System.Drawing.Size(67, 25);
             this.miscDefaultButton.TabIndex = 36;
             this.miscDefaultButton.Text = "Default";
             this.toolTip1.SetToolTip(this.miscDefaultButton, "Set to Tunny\'s default value.");
@@ -2001,10 +2065,10 @@ namespace Tunny.UI
             "Always",
             "HasGeometry",
             "NoExecute"});
-            this.runGarbageCollectionComboBox.Location = new System.Drawing.Point(236, 14);
-            this.runGarbageCollectionComboBox.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            this.runGarbageCollectionComboBox.Location = new System.Drawing.Point(157, 9);
+            this.runGarbageCollectionComboBox.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.runGarbageCollectionComboBox.Name = "runGarbageCollectionComboBox";
-            this.runGarbageCollectionComboBox.Size = new System.Drawing.Size(169, 31);
+            this.runGarbageCollectionComboBox.Size = new System.Drawing.Size(114, 23);
             this.runGarbageCollectionComboBox.TabIndex = 34;
             this.runGarbageCollectionComboBox.Text = "HasGeometry";
             this.runGarbageCollectionComboBox.SelectedIndexChanged += new System.EventHandler(this.RunGarbageCollectionComboBox_SelectedIndexChanged);
@@ -2012,9 +2076,10 @@ namespace Tunny.UI
             // runGarbageCollectionLabel
             // 
             this.runGarbageCollectionLabel.AutoSize = true;
-            this.runGarbageCollectionLabel.Location = new System.Drawing.Point(6, 16);
+            this.runGarbageCollectionLabel.Location = new System.Drawing.Point(4, 11);
+            this.runGarbageCollectionLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.runGarbageCollectionLabel.Name = "runGarbageCollectionLabel";
-            this.runGarbageCollectionLabel.Size = new System.Drawing.Size(214, 23);
+            this.runGarbageCollectionLabel.Size = new System.Drawing.Size(142, 15);
             this.runGarbageCollectionLabel.TabIndex = 33;
             this.runGarbageCollectionLabel.Text = "Run Garbage Collection";
             this.toolTip1.SetToolTip(this.runGarbageCollectionLabel, "Setting whether or not per-trial data is targeted for garbage collection");
@@ -2024,19 +2089,21 @@ namespace Tunny.UI
             this.fileTabPage.Controls.Add(this.outputDebugLogButton);
             this.fileTabPage.Controls.Add(this.groupBox1);
             this.fileTabPage.Controls.Add(this.licenseGroupBox);
-            this.fileTabPage.Location = new System.Drawing.Point(4, 32);
+            this.fileTabPage.Location = new System.Drawing.Point(4, 24);
+            this.fileTabPage.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.fileTabPage.Name = "fileTabPage";
-            this.fileTabPage.Padding = new System.Windows.Forms.Padding(3);
-            this.fileTabPage.Size = new System.Drawing.Size(428, 442);
+            this.fileTabPage.Padding = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.fileTabPage.Size = new System.Drawing.Size(283, 291);
             this.fileTabPage.TabIndex = 4;
             this.fileTabPage.Text = "File";
             this.fileTabPage.UseVisualStyleBackColor = true;
             // 
             // outputDebugLogButton
             // 
-            this.outputDebugLogButton.Location = new System.Drawing.Point(80, 388);
+            this.outputDebugLogButton.Location = new System.Drawing.Point(53, 259);
+            this.outputDebugLogButton.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.outputDebugLogButton.Name = "outputDebugLogButton";
-            this.outputDebugLogButton.Size = new System.Drawing.Size(264, 38);
+            this.outputDebugLogButton.Size = new System.Drawing.Size(176, 25);
             this.outputDebugLogButton.TabIndex = 10;
             this.outputDebugLogButton.Text = "Output Debug Log";
             this.outputDebugLogButton.UseVisualStyleBackColor = true;
@@ -2047,19 +2114,21 @@ namespace Tunny.UI
             this.groupBox1.Controls.Add(this.setResultFilePathButton);
             this.groupBox1.Controls.Add(this.clearResultButton);
             this.groupBox1.Controls.Add(this.openResultFolderButton);
-            this.groupBox1.Location = new System.Drawing.Point(22, 6);
+            this.groupBox1.Location = new System.Drawing.Point(15, 4);
+            this.groupBox1.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(378, 200);
+            this.groupBox1.Padding = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.groupBox1.Size = new System.Drawing.Size(252, 133);
             this.groupBox1.TabIndex = 9;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Result";
             // 
             // setResultFilePathButton
             // 
-            this.setResultFilePathButton.Location = new System.Drawing.Point(58, 34);
-            this.setResultFilePathButton.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            this.setResultFilePathButton.Location = new System.Drawing.Point(39, 23);
+            this.setResultFilePathButton.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.setResultFilePathButton.Name = "setResultFilePathButton";
-            this.setResultFilePathButton.Size = new System.Drawing.Size(264, 39);
+            this.setResultFilePathButton.Size = new System.Drawing.Size(176, 26);
             this.setResultFilePathButton.TabIndex = 7;
             this.setResultFilePathButton.Text = "Set file path";
             this.setResultFilePathButton.UseVisualStyleBackColor = true;
@@ -2067,10 +2136,10 @@ namespace Tunny.UI
             // 
             // clearResultButton
             // 
-            this.clearResultButton.Location = new System.Drawing.Point(58, 136);
-            this.clearResultButton.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            this.clearResultButton.Location = new System.Drawing.Point(39, 91);
+            this.clearResultButton.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.clearResultButton.Name = "clearResultButton";
-            this.clearResultButton.Size = new System.Drawing.Size(264, 42);
+            this.clearResultButton.Size = new System.Drawing.Size(176, 28);
             this.clearResultButton.TabIndex = 5;
             this.clearResultButton.Text = "Clear file";
             this.clearResultButton.UseVisualStyleBackColor = true;
@@ -2078,10 +2147,10 @@ namespace Tunny.UI
             // 
             // openResultFolderButton
             // 
-            this.openResultFolderButton.Location = new System.Drawing.Point(58, 86);
-            this.openResultFolderButton.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            this.openResultFolderButton.Location = new System.Drawing.Point(39, 57);
+            this.openResultFolderButton.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.openResultFolderButton.Name = "openResultFolderButton";
-            this.openResultFolderButton.Size = new System.Drawing.Size(264, 39);
+            this.openResultFolderButton.Size = new System.Drawing.Size(176, 26);
             this.openResultFolderButton.TabIndex = 6;
             this.openResultFolderButton.Text = "Open folder";
             this.openResultFolderButton.UseVisualStyleBackColor = true;
@@ -2091,19 +2160,21 @@ namespace Tunny.UI
             // 
             this.licenseGroupBox.Controls.Add(this.showThirdPartyLicenseButton);
             this.licenseGroupBox.Controls.Add(this.showTunnyLicenseButton);
-            this.licenseGroupBox.Location = new System.Drawing.Point(22, 212);
+            this.licenseGroupBox.Location = new System.Drawing.Point(15, 141);
+            this.licenseGroupBox.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.licenseGroupBox.Name = "licenseGroupBox";
-            this.licenseGroupBox.Size = new System.Drawing.Size(378, 158);
+            this.licenseGroupBox.Padding = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.licenseGroupBox.Size = new System.Drawing.Size(252, 105);
             this.licenseGroupBox.TabIndex = 8;
             this.licenseGroupBox.TabStop = false;
             this.licenseGroupBox.Text = "License";
             // 
             // showThirdPartyLicenseButton
             // 
-            this.showThirdPartyLicenseButton.Location = new System.Drawing.Point(58, 98);
-            this.showThirdPartyLicenseButton.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            this.showThirdPartyLicenseButton.Location = new System.Drawing.Point(39, 65);
+            this.showThirdPartyLicenseButton.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.showThirdPartyLicenseButton.Name = "showThirdPartyLicenseButton";
-            this.showThirdPartyLicenseButton.Size = new System.Drawing.Size(264, 42);
+            this.showThirdPartyLicenseButton.Size = new System.Drawing.Size(176, 28);
             this.showThirdPartyLicenseButton.TabIndex = 8;
             this.showThirdPartyLicenseButton.Text = "Show Third Party License";
             this.showThirdPartyLicenseButton.UseVisualStyleBackColor = true;
@@ -2111,10 +2182,10 @@ namespace Tunny.UI
             // 
             // showTunnyLicenseButton
             // 
-            this.showTunnyLicenseButton.Location = new System.Drawing.Point(58, 44);
-            this.showTunnyLicenseButton.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            this.showTunnyLicenseButton.Location = new System.Drawing.Point(39, 29);
+            this.showTunnyLicenseButton.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.showTunnyLicenseButton.Name = "showTunnyLicenseButton";
-            this.showTunnyLicenseButton.Size = new System.Drawing.Size(264, 42);
+            this.showTunnyLicenseButton.Size = new System.Drawing.Size(176, 28);
             this.showTunnyLicenseButton.TabIndex = 7;
             this.showTunnyLicenseButton.Text = "Show Tunny License";
             this.showTunnyLicenseButton.UseVisualStyleBackColor = true;
@@ -2122,13 +2193,13 @@ namespace Tunny.UI
             // 
             // OptimizationWindow
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(144F, 144F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-            this.ClientSize = new System.Drawing.Size(434, 484);
+            this.ClientSize = new System.Drawing.Size(289, 323);
             this.Controls.Add(this.optimizeTabControl);
             this.Font = new System.Drawing.Font("Meiryo UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(128)));
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            this.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
             this.Name = "OptimizationWindow";
             this.Text = "Tunny";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.FormClosingXButton);

--- a/Tunny/UI/Tab/OptimizeTab.cs
+++ b/Tunny/UI/Tab/OptimizeTab.cs
@@ -241,19 +241,20 @@ namespace Tunny.UI
         private void OptimizeProgressChangedHandler(object sender, ProgressChangedEventArgs e)
         {
             TLog.MethodStart();
-            var pState = (ProgressState)e.UserState;
-            if (!pState.IsReportOnly)
+            var progressState = (ProgressState)e.UserState;
+            if (!progressState.IsReportOnly)
             {
-                _component.UpdateGrasshopper(pState.Parameter);
+                _component.UpdateGrasshopper(progressState.Parameter);
             }
+            _component.GrasshopperStatus = GrasshopperStates.RequestProcessed;
             const string trialNumLabel = "Trial: ";
             optimizeTrialNumLabel.Text = e.ProgressPercentage == 100
                 ? trialNumLabel + "#"
-                : trialNumLabel + (pState.TrialNumber + 1);
-            SetBestValues(e, pState);
+                : trialNumLabel + (progressState.TrialNumber + 1);
+            SetBestValues(e, progressState);
 
-            EstimatedTimeRemainingLabel.Text = pState.EstimatedTimeRemaining.TotalSeconds > 0
-                ? "Estimated Time Remaining: " + new DateTime(0).Add(pState.EstimatedTimeRemaining).ToString("HH:mm:ss", CultureInfo.InvariantCulture)
+            EstimatedTimeRemainingLabel.Text = progressState.EstimatedTimeRemaining.TotalSeconds > 0
+                ? "Estimated Time Remaining: " + new DateTime(0).Add(progressState.EstimatedTimeRemaining).ToString("HH:mm:ss", CultureInfo.InvariantCulture)
                 : "Estimated Time Remaining: 00:00:00";
             optimizeProgressBar.Value = e.ProgressPercentage;
             optimizeProgressBar.Update();

--- a/Tunny/UI/Tab/OptimizeTab.cs
+++ b/Tunny/UI/Tab/OptimizeTab.cs
@@ -242,11 +242,7 @@ namespace Tunny.UI
         {
             TLog.MethodStart();
             var progressState = (ProgressState)e.UserState;
-            if (!progressState.IsReportOnly)
-            {
-                _component.UpdateGrasshopper(progressState.Parameter);
-            }
-            _component.GrasshopperStatus = GrasshopperStates.RequestProcessed;
+            _component.UpdateGrasshopper(progressState);
             const string trialNumLabel = "Trial: ";
             optimizeTrialNumLabel.Text = e.ProgressPercentage == 100
                 ? trialNumLabel + "#"

--- a/Tunny/UI/Tab/OutputTab.cs
+++ b/Tunny/UI/Tab/OutputTab.cs
@@ -24,10 +24,10 @@ namespace Tunny.UI
             RunOutputLoop(OutputMode.AllTrials);
         }
 
-        private void OutputModelNumberButton_Click(object sender, EventArgs e)
+        private void OutputTrialNumberButton_Click(object sender, EventArgs e)
         {
             TLog.MethodStart();
-            RunOutputLoop(OutputMode.ModelNumber);
+            RunOutputLoop(OutputMode.TrialNumber);
         }
 
         private void ReflectToSliderButton_Click(object sender, EventArgs e)
@@ -69,15 +69,15 @@ namespace Tunny.UI
                 case OutputMode.AllTrials:
                     OutputLoop.Indices = new[] { -10 };
                     break;
-                case OutputMode.ModelNumber:
-                    result = ParseModelNumberInput(ref indices);
+                case OutputMode.TrialNumber:
+                    result = ParseTrialNumberInput(ref indices);
                     if (result)
                     {
                         OutputLoop.Indices = indices.ToArray();
                     }
                     break;
                 case OutputMode.ReflectToSliders:
-                    result = ParseModelNumberInput(ref indices);
+                    result = ParseTrialNumberInput(ref indices);
                     if (result)
                     {
                         CheckIndicesLength(indices.ToArray());
@@ -90,7 +90,7 @@ namespace Tunny.UI
             return result;
         }
 
-        private bool ParseModelNumberInput(ref List<int> indices)
+        private bool ParseTrialNumberInput(ref List<int> indices)
         {
             TLog.MethodStart();
             bool result = true;
@@ -110,7 +110,7 @@ namespace Tunny.UI
             TLog.MethodStart();
             if (indices.Length > 1)
             {
-                UseFirstModelNumberToReflectMessage();
+                UseFirstTrialNumberToReflectMessage();
             }
         }
 
@@ -123,7 +123,7 @@ namespace Tunny.UI
             {
                 case OutputMode.ParatoSolutions:
                 case OutputMode.AllTrials:
-                case OutputMode.ModelNumber:
+                case OutputMode.TrialNumber:
                     _component.ExpireSolution(true);
                     break;
                 case OutputMode.ReflectToSliders:

--- a/Tunny/UI/Tab/UITunnyMessages.cs
+++ b/Tunny/UI/Tab/UITunnyMessages.cs
@@ -61,11 +61,11 @@ namespace Tunny.UI
             return false;
         }
 
-        private static void UseFirstModelNumberToReflectMessage()
+        private static void UseFirstTrialNumberToReflectMessage()
         {
             TLog.MethodStart();
             TunnyMessageBox.Show(
-                "You input multi model numbers, but this function only reflect variables to slider or gene pool to first one.",
+                "You input multi trial numbers, but this function only reflect variables to slider or gene pool to first one.",
                 "Tunny"
             );
         }


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Reference Issues/PRs

<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

#306 

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
### Changed
- After optimization is finished, a window allows the user to choose whether to reinstate the results or not.
- The words "reflect" and "restore" are changed to "reinstate" to match the Galapagos expression.
- ModelNumber in the output section is changed to TrialNumber.

### Fixed

- MessageBox is now not below the back of Grasshopper window.