### PR TITLE
Fix/fish print by path lock image file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@ for now removed features.
 
 ### Fixed
 
-- Tunny UI wont wake up when rhino7(net4.8) version settings file deserialize
+- Tunny UI wont wake up when rhino7(net4.8) version settings file deserialize.
+- FishPrintByPath locks the image.
 
 ### Security
 

--- a/Tunny/Component/Print/FishPrintByPath.cs
+++ b/Tunny/Component/Print/FishPrintByPath.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Drawing;
+using System.IO;
 
 using Grasshopper.Kernel;
 
@@ -37,12 +38,16 @@ namespace Tunny.Component.Print
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Path is empty.");
                 return;
             }
-            if (!System.IO.File.Exists(path))
+            if (!File.Exists(path))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "File not found.");
                 return;
             }
-            var bitmap = Image.FromFile(path) as Bitmap;
+
+            var fs = new FileStream(path, FileMode.Open, FileAccess.Read);
+            var bitmap = Image.FromStream(fs) as Bitmap;
+            fs.Close();
+
             DA.SetData(0, bitmap);
         }
 


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Reference Issues/PRs

<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->

Fix　FishPrintByPath locks image file