### PR TITLE
Fix pruner `auto` value parse

### DIFF
--- a/Optuna/Pruner/HyperbandPruner.cs
+++ b/Optuna/Pruner/HyperbandPruner.cs
@@ -21,11 +21,18 @@ namespace Optuna.Pruner
 
         public dynamic ToPython(dynamic optuna)
         {
-            return optuna.pruners.HyperbandPruner(
-                min_resource: MinResource,
-                max_resource: MaxResource,
-                reduction_factor: ReductionFactor,
-                bootstrap_count: BootstrapCount);
+            bool parseResult = int.TryParse(MaxResource, out int intMaxResource);
+            return parseResult && intMaxResource > MinResource
+                ? optuna.pruners.HyperbandPruner(
+                    min_resource: MinResource,
+                    max_resource: intMaxResource,
+                    reduction_factor: ReductionFactor,
+                    bootstrap_count: BootstrapCount)
+                : optuna.pruners.HyperbandPruner(
+                    min_resource: MinResource,
+                    max_resource: "auto",
+                    reduction_factor: ReductionFactor,
+                    bootstrap_count: BootstrapCount);
         }
     }
 }

--- a/Optuna/Pruner/SuccessiveHalvingPruner.cs
+++ b/Optuna/Pruner/SuccessiveHalvingPruner.cs
@@ -21,11 +21,18 @@ namespace Optuna.Pruner
 
         public dynamic ToPython(dynamic optuna)
         {
-            return optuna.pruners.SuccessiveHalvingPruner(
-                min_resource: MinResource,
-                reduction_factor: ReductionFactor,
-                min_early_stopping_rate: MinEarlyStoppingRate,
-                bootstrap_count: BootstrapCount);
+            bool parseResult = int.TryParse(MinResource, out int intMinResource);
+            return parseResult && intMinResource > 0
+                ? optuna.pruners.SuccessiveHalvingPruner(
+                    min_resource: intMinResource,
+                    reduction_factor: ReductionFactor,
+                    min_early_stopping_rate: MinEarlyStoppingRate,
+                    bootstrap_count: BootstrapCount)
+                : optuna.pruners.SuccessiveHalvingPruner(
+                    min_resource: "auto",
+                    reduction_factor: ReductionFactor,
+                    min_early_stopping_rate: MinEarlyStoppingRate,
+                    bootstrap_count: BootstrapCount);
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Reference Issues/PRs

<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
- Fix pruner `auto` value parse
