### PR TITLE
Add error handling for objective value checks in TunnyMessageBox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ Please see [here](https://github.com/hrntsm/Tunny/releases) for the data release
   - For Rhino8
 - Support apple silicon mac Rhino8
   - using eto UI
+- Objective input values check
+  - if null or list or tree input to objectives, Tunny throw error.
 
 ### Changed
 

--- a/Tunny/Eto/Message/TunnyMessageBox_error.cs
+++ b/Tunny/Eto/Message/TunnyMessageBox_error.cs
@@ -7,6 +7,28 @@ namespace Tunny.Eto.Message
 {
     internal static partial class TunnyMessageBox
     {
+        internal static bool Error_ObjectiveHasSomeValue(string nickname)
+        {
+            TLog.MethodStart();
+            Show(
+                $"Objective \"{nickname}\" has some values(List or Tree input). \nPlease connect a single number or FishPrint to the objective.",
+                "Tunny",
+                MessageBoxButtons.OK,
+                MessageBoxType.Error);
+            return false;
+        }
+
+        internal static bool Error_ObjectiveIsNull(string nickname)
+        {
+            TLog.MethodStart();
+            Show(
+                $"Objective \"{nickname}\" is null. \nPlease connect a single number or FishPrint to the objective.",
+                "Tunny",
+                MessageBoxButtons.OK,
+                MessageBoxType.Error);
+            return false;
+        }
+
         internal static void Error_RhinoCodePythonNotFound()
         {
             TLog.MethodStart();

--- a/Tunny/Util/GrasshopperInOut.cs
+++ b/Tunny/Util/GrasshopperInOut.cs
@@ -270,15 +270,7 @@ namespace Tunny.Util
             var unsupportedObjectives = new List<IGH_Param>();
             foreach (IGH_Param param in _component.Params.Input[1].Sources)
             {
-                switch (param)
-                {
-                    case Param_Number _:
-                    case Param_FishPrint _:
-                        break;
-                    default:
-                        unsupportedObjectives.Add(param);
-                        break;
-                }
+                if (!CheckObjectiveValueCount(unsupportedObjectives, param)) { return false; }
             }
             if (unsupportedObjectives.Count > 0)
             {
@@ -286,6 +278,29 @@ namespace Tunny.Util
             }
             if (!CheckObjectiveNicknameDuplication(_component.Params.Input[1].Sources.ToArray())) { return false; }
             _objectives = new Objective(_component.Params.Input[1].Sources.ToList());
+            return true;
+        }
+
+        private static bool CheckObjectiveValueCount(List<IGH_Param> unsupportedObjectives, IGH_Param param)
+        {
+            switch (param)
+            {
+                case Param_Number _:
+                case Param_FishPrint _:
+                    if (param.VolatileDataCount == 0)
+                    {
+                        return TunnyMessageBox.Error_ObjectiveIsNull(param.NickName);
+                    }
+                    else if (param.VolatileDataCount >= 2)
+                    {
+                        return TunnyMessageBox.Error_ObjectiveHasSomeValue(param.NickName);
+                    }
+                    break;
+                default:
+                    unsupportedObjectives.Add(param);
+                    break;
+            }
+
             return true;
         }
 


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Reference Issues/PRs

<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
- Objective input values check
  - if null or list or tree input to objectives, Tunny throw error.