### PR TITLE
Feature/improve log loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@ Please see [here](https://github.com/hrntsm/Tunny/releases) for the data release
   - Disable when Tunny UI wake up
   - Enable when Tunny UI closed
 - For improve visibility, ConstructFishAttribute is colored.
+- Improve result log file load speed.
+  - Tunny was loading the result file when launching the UI, and when the log file was large, it took a long time to launch.
+  - With this update, log files are now about 60 times faster to load.
+    - What used to take about 5 minutes to load the results of 30,000 trials can now be loaded in about 5 seconds.
 - Update optuna v4.2
 - Update python v3.10 to v3.12
 

--- a/Optuna/Storage/Journal/Storage.cs
+++ b/Optuna/Storage/Journal/Storage.cs
@@ -13,8 +13,14 @@ namespace Optuna.Storage.Journal
     public class JournalStorage : IOptunaStorage
     {
         private readonly Dictionary<int, Study.Study> _studies = new Dictionary<int, Study.Study>();
+        private readonly Dictionary<int, Trial.Trial> _trialCache = new Dictionary<int, Trial.Trial>();
+        private readonly Dictionary<string, int> _studyNameToIdIndex = new Dictionary<string, int>();
+        private readonly object _initLock = new object();
+        private readonly string _filePath;
         private int _nextStudyId;
         private int _trialId;
+        private bool _isInitialized;
+        private bool _isInitialing;
 
         public JournalStorage(string path, bool createIfNotExist = false)
         {
@@ -27,165 +33,232 @@ namespace Optuna.Storage.Journal
                 else
                 {
                     File.Create(path).Close();
+                    _isInitialized = true;
                 }
             }
+            _filePath = path;
+        }
 
-            var logs = new List<string>();
-            using (FileStream fs = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+        private void EnsureInitialized()
+        {
+            if (_isInitialized || _isInitialing)
+            {
+                return;
+            }
+
+            lock (_initLock)
+            {
+                if (_isInitialized || _isInitialing)
+                {
+                    return;
+                }
+
+                _isInitialing = true;
+                LoadDataFromFile();
+                _isInitialized = true;
+                _isInitialing = false;
+            }
+        }
+
+        private void LoadDataFromFile()
+        {
+            const int BufferSize = 65536;
+            var jsonBatch = new List<string>(1000);
+
+            using (var fs = new FileStream(_filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, BufferSize))
             {
                 using (var sr = new StreamReader(fs))
                 {
-                    while (sr.Peek() >= 0)
+                    string line;
+                    while ((line = sr.ReadLine()) != null)
                     {
-                        logs.Add(sr.ReadLine());
+                        if (string.IsNullOrWhiteSpace(line))
+                        {
+                            continue;
+                        }
+
+                        jsonBatch.Add(line);
+                        if (jsonBatch.Count >= 1000)
+                        {
+                            ProcessJsonBatch(jsonBatch);
+                            jsonBatch.Clear();
+                        }
+                    }
+
+                    if (jsonBatch.Count > 0)
+                    {
+                        ProcessJsonBatch(jsonBatch);
                     }
                 }
+
+                BuildIndices();
+            }
+        }
+
+        private void BuildIndices()
+        {
+            foreach (Study.Study study in _studies.Values)
+            {
+                _studyNameToIdIndex[study.StudyName] = study.StudyId;
             }
 
-            foreach (string log in logs)
+            foreach (Study.Study study in _studies.Values)
             {
-                if (log == "")
+                foreach (Trial.Trial trial in study.Trials)
                 {
-                    continue;
+                    _trialCache[trial.TrialId] = trial;
                 }
+            }
+        }
 
-                var logObject = JObject.Parse(log);
+        private void ProcessJsonBatch(List<string> jsonBatch)
+        {
+            foreach (string json in jsonBatch)
+            {
+                var logObject = JObject.Parse(json);
                 var opCode = (JournalOperation)Enum.ToObject(typeof(JournalOperation), (int)logObject["op_code"]);
-                switch (opCode)
-                {
-                    case JournalOperation.CreateStudy:
+                ProcessLogEntry(opCode, logObject);
+            }
+        }
+
+        private void ProcessLogEntry(JournalOperation opCode, JObject logObject)
+        {
+            switch (opCode)
+            {
+                case JournalOperation.CreateStudy:
+                    {
                         StudyDirection[] studyDirections = logObject["directions"].ToObject<StudyDirection[]>();
                         string studyName = logObject["study_name"].ToString();
                         CreateNewStudy(studyDirections, studyName);
                         break;
-                    case JournalOperation.DeleteStudy:
-                        {
-                            int studyId = (int)logObject["study_id"];
-                            DeleteStudy(studyId);
-                        }
+                    }
+                case JournalOperation.DeleteStudy:
+                    {
+                        int studyId = (int)logObject["study_id"];
+                        DeleteStudy(studyId);
                         break;
-                    case JournalOperation.SetStudyUserAttr:
+                    }
+                case JournalOperation.SetStudyUserAttr:
+                    {
+                        int studyId = (int)logObject["study_id"];
+                        var userAttr = (JObject)logObject["user_attr"];
+                        foreach (KeyValuePair<string, JToken> item in userAttr)
                         {
-                            int studyId = (int)logObject["study_id"];
-                            var userAttr = (JObject)logObject["user_attr"];
-                            foreach (KeyValuePair<string, JToken> item in userAttr)
+                            string[] values = item.Value.Select(v => v.ToString()).ToArray();
+                            if (values == null || values.Length == 0)
                             {
-                                string[] values = item.Value.Select(v => v.ToString()).ToArray();
-                                if (values == null || values.Length == 0)
-                                {
-                                    values = new string[] { item.Value.ToString() };
-                                }
-                                SetStudyUserAttr(studyId, item.Key, values);
+                                values = new string[] { item.Value.ToString() };
                             }
+                            SetStudyUserAttr(studyId, item.Key, values);
                         }
                         break;
-                    case JournalOperation.SetStudySystemAttr:
+                    }
+                case JournalOperation.SetStudySystemAttr:
+                    {
+                        int studyId = (int)logObject["study_id"];
+                        var systemAttr = (JObject)logObject["system_attr"];
+                        foreach (KeyValuePair<string, JToken> item in systemAttr)
                         {
-                            int studyId = (int)logObject["study_id"];
-                            var systemAttr = (JObject)logObject["system_attr"];
-                            foreach (KeyValuePair<string, JToken> item in systemAttr)
+                            string[] values = item.Value.Select(v => v.ToString()).ToArray();
+                            if (values == null || values.Length == 0)
                             {
-                                string[] values = item.Value.Select(v => v.ToString()).ToArray();
-                                if (values == null || values.Length == 0)
-                                {
-                                    values = new string[] { item.Value.ToString() };
-                                }
-                                SetStudySystemAttr(studyId, item.Key, values);
+                                values = new string[] { item.Value.ToString() };
                             }
+                            SetStudySystemAttr(studyId, item.Key, values);
                         }
                         break;
-                    case JournalOperation.CreateTrial:
+                    }
+                case JournalOperation.CreateTrial:
+                    {
+                        int studyId = (int)logObject["study_id"];
+                        Trial.Trial trial;
+                        if (logObject["datetime_complete"] == null)
                         {
-                            int studyId = (int)logObject["study_id"];
-                            Trial.Trial trial;
-                            if (logObject["datetime_complete"] == null)
+                            trial = new Trial.Trial();
+                            JToken start = logObject["datetime_start"];
+                            if (start != null && start.HasValues)
                             {
-                                trial = new Trial.Trial();
-                                JToken start = logObject["datetime_start"];
-                                if (start != null && start.HasValues)
-                                {
-                                    trial.DatetimeStart = (DateTime)start;
-                                }
-                                CreateNewTrial(studyId, trial);
+                                trial.DatetimeStart = (DateTime)start;
                             }
-                            else
+                            CreateNewTrial(studyId, trial);
+                        }
+                        else
+                        {
+                            Dictionary<string, object> trialParams = logObject["params"].ToObject<Dictionary<string, object>>();
+                            var trialParamsWithType = new Dictionary<string, object>();
+                            foreach (KeyValuePair<string, object> item in trialParams)
                             {
-                                Dictionary<string, object> trialParams = logObject["params"].ToObject<Dictionary<string, object>>();
-                                var trialParamsWithType = new Dictionary<string, object>();
-                                foreach (KeyValuePair<string, object> item in trialParams)
+                                switch (item.Value)
                                 {
-                                    switch (item.Value)
-                                    {
-                                        case double d:
-                                            trialParamsWithType[item.Key] = d;
-                                            break;
-                                        case string s:
-                                            trialParamsWithType[item.Key] = s;
-                                            break;
-                                        case int i:
-                                            trialParamsWithType[item.Key] = i;
-                                            break;
-                                        default:
-                                            trialParamsWithType[item.Key] = item.Value;
-                                            break;
-                                    }
+                                    case double d:
+                                        trialParamsWithType[item.Key] = d;
+                                        break;
+                                    case string s:
+                                        trialParamsWithType[item.Key] = s;
+                                        break;
+                                    case int i:
+                                        trialParamsWithType[item.Key] = i;
+                                        break;
+                                    default:
+                                        trialParamsWithType[item.Key] = item.Value;
+                                        break;
                                 }
-                                var values = new List<double>();
-                                foreach (JToken value in logObject["values"])
-                                {
-                                    values.Add(value.ToObject<double>());
-                                }
-                                if (logObject["value"].Type != JTokenType.Null)
-                                {
-                                    values.Add((double)logObject["value"]);
-                                }
-                                trial = new Trial.Trial
-                                {
-                                    Values = values.ToArray(),
-                                    Params = trialParamsWithType,
-                                    State = (TrialState)Enum.ToObject(typeof(TrialState), (int)logObject["state"]),
-                                    DatetimeStart = (DateTime)logObject["datetime_start"],
-                                    DatetimeComplete = (DateTime)logObject["datetime_complete"],
-                                };
-                                CreateNewTrial(studyId, trial);
-                                SetTrialSystemAttrFromJObject(trial.TrialId, (JObject)logObject["system_attrs"]);
-                                SetTrialUserAttrFromJObject(trial.TrialId, (JObject)logObject["user_attrs"]);
                             }
+                            var values = new List<double>();
+                            foreach (JToken value in logObject["values"])
+                            {
+                                values.Add(value.ToObject<double>());
+                            }
+                            if (logObject["value"].Type != JTokenType.Null)
+                            {
+                                values.Add((double)logObject["value"]);
+                            }
+                            trial = new Trial.Trial
+                            {
+                                Values = values.ToArray(),
+                                Params = trialParamsWithType,
+                                State = (TrialState)Enum.ToObject(typeof(TrialState), (int)logObject["state"]),
+                                DatetimeStart = (DateTime)logObject["datetime_start"],
+                                DatetimeComplete = (DateTime)logObject["datetime_complete"],
+                            };
+                            CreateNewTrial(studyId, trial);
+                            SetTrialSystemAttrFromJObject(trial.TrialId, (JObject)logObject["system_attrs"]);
+                            SetTrialUserAttrFromJObject(trial.TrialId, (JObject)logObject["user_attrs"]);
                         }
                         break;
-                    case JournalOperation.SetTrialParam:
-                        {
-                            int trialId = (int)logObject["trial_id"];
-                            string paramName = (string)logObject["param_name"];
-                            double paramValueInternal = (double)logObject["param_value_internal"];
-                            SetTrailParam(trialId, paramName, paramValueInternal, null);
-                        }
+                    }
+                case JournalOperation.SetTrialParam:
+                    {
+                        int trialId = (int)logObject["trial_id"];
+                        string paramName = (string)logObject["param_name"];
+                        double paramValueInternal = (double)logObject["param_value_internal"];
+                        SetTrailParam(trialId, paramName, paramValueInternal, null);
                         break;
-                    case JournalOperation.SetTrialStateValues:
-                        {
-                            int trialId = (int)logObject["trial_id"];
-                            double[] trialValues = logObject["values"].Select(v => v.ToObject<double>()).ToArray();
-                            var trialState = (TrialState)Enum.ToObject(typeof(TrialState), (int)logObject["state"]);
-                            SetTrialStateValue(trialId, trialState, trialValues);
-                        }
+                    }
+                case JournalOperation.SetTrialStateValues:
+                    {
+                        int trialId = (int)logObject["trial_id"];
+                        double[] trialValues = logObject["values"].Select(v => v.ToObject<double>()).ToArray();
+                        var trialState = (TrialState)Enum.ToObject(typeof(TrialState), (int)logObject["state"]);
+                        SetTrialStateValue(trialId, trialState, trialValues);
                         break;
-                    case JournalOperation.SetTrialIntermediateValue:
+                    }
+                case JournalOperation.SetTrialIntermediateValue:
+                    break;
+                case JournalOperation.SetTrialUserAttr:
+                    {
+                        int trialId = (int)logObject["trial_id"];
+                        var userAttr = (JObject)logObject["user_attr"];
+                        SetTrialUserAttrFromJObject(trialId, userAttr);
                         break;
-                    case JournalOperation.SetTrialUserAttr:
-                        {
-                            int trialId = (int)logObject["trial_id"];
-                            var userAttr = (JObject)logObject["user_attr"];
-                            SetTrialUserAttrFromJObject(trialId, userAttr);
-                        }
+                    }
+                case JournalOperation.SetTrialSystemAttr:
+                    {
+                        int trialId = (int)logObject["trial_id"];
+                        var systemAttr = (JObject)logObject["system_attr"];
+                        SetTrialSystemAttrFromJObject(trialId, systemAttr);
                         break;
-                    case JournalOperation.SetTrialSystemAttr:
-                        {
-                            int trialId = (int)logObject["trial_id"];
-                            var systemAttr = (JObject)logObject["system_attr"];
-                            SetTrialSystemAttrFromJObject(trialId, systemAttr);
-                        }
-                        break;
-                }
+                    }
             }
         }
 
@@ -222,10 +295,13 @@ namespace Optuna.Storage.Journal
 
         public int CreateNewStudy(StudyDirection[] studyDirections, string studyName = "")
         {
-            string[] studyNames = _studies.Values.Select(s => s.StudyName).ToArray();
-            if (!studyNames.Contains(studyName))
+            EnsureInitialized();
+
+            if (!_studyNameToIdIndex.ContainsKey(studyName))
             {
-                _studies.Add(_nextStudyId, new Study.Study(this, _nextStudyId, studyName, studyDirections));
+                var study = new Study.Study(this, _nextStudyId, studyName, studyDirections);
+                _studies.Add(_nextStudyId, study);
+                _studyNameToIdIndex[studyName] = _nextStudyId;
                 _nextStudyId++;
             }
             return _nextStudyId;
@@ -233,38 +309,68 @@ namespace Optuna.Storage.Journal
 
         public int CreateNewTrial(int studyId, Trial.Trial templateTrial = null)
         {
+            EnsureInitialized();
+
             Trial.Trial trial = templateTrial ?? new Trial.Trial();
             trial.TrialId = _trialId++;
             trial.Number = _studies[studyId].Trials.Count;
             _studies[studyId].Trials.Add(trial);
+            _trialCache[trial.TrialId] = trial;
             return _trialId;
         }
 
         public void DeleteStudy(int studyId)
         {
-            _studies.Remove(studyId);
+            EnsureInitialized();
+
+            if (_studies.TryGetValue(studyId, out Study.Study study))
+            {
+                foreach (Trial.Trial trial in study.Trials)
+                {
+                    _trialCache.Remove(trial.TrialId);
+                }
+
+                _studyNameToIdIndex.Remove(study.StudyName);
+                _studies.Remove(studyId);
+            }
         }
 
         public Study.Study[] GetAllStudies()
         {
+            EnsureInitialized();
+
             return _studies.Values.ToArray();
         }
 
         public Trial.Trial[] GetAllTrials(int studyId, bool deepcopy = true)
         {
-            return _studies[studyId].Trials.ToArray();
+            EnsureInitialized();
+
+            if (!_studies.TryGetValue(studyId, out Study.Study study))
+            {
+                throw new KeyNotFoundException($"Study with ID '{studyId}' not found.");
+            }
+
+            return study.Trials.ToArray();
         }
 
         public Trial.Trial GetBestTrial(int studyId)
         {
-            List<Trial.Trial> allTrials = _studies[studyId].Trials.FindAll(trial => trial.State == TrialState.COMPLETE);
+            EnsureInitialized();
+
+            if (!_studies.TryGetValue(studyId, out Study.Study study))
+            {
+                throw new KeyNotFoundException($"Study with ID '{studyId}' not found.");
+            }
+
+            var allTrials = study.Trials.Where(trial => trial.State == TrialState.COMPLETE).ToList();
 
             if (allTrials.Count == 0)
             {
                 return null;
             }
 
-            StudyDirection[] directions = GetStudyDirections(studyId);
+            StudyDirection[] directions = study.Directions;
             if (directions.Length != 1)
             {
                 throw new InvalidOperationException("Study is multi-objective.");
@@ -282,68 +388,169 @@ namespace Optuna.Storage.Journal
 
         public int GetNTrials(int studyId)
         {
-            return _studies[studyId].Trials.Count;
+            EnsureInitialized();
+
+            if (!_studies.TryGetValue(studyId, out Study.Study study))
+            {
+                throw new KeyNotFoundException($"Study with ID '{studyId}' not found.");
+            }
+
+            return study.Trials.Count;
         }
 
         public StudyDirection[] GetStudyDirections(int studyId)
         {
-            return _studies[studyId].Directions;
+            EnsureInitialized();
+
+            if (!_studies.TryGetValue(studyId, out Study.Study study))
+            {
+                throw new KeyNotFoundException($"Study with ID '{studyId}' not found.");
+            }
+
+            return study.Directions;
         }
 
         public int GetStudyIdFromName(string studyName)
         {
-            return _studies.Values.First(s => s.StudyName == studyName).StudyId;
+            EnsureInitialized();
+
+            if (_studyNameToIdIndex.TryGetValue(studyName, out int studyId))
+            {
+                return studyId;
+            }
+
+            throw new KeyNotFoundException($"Study with name '{studyName}' not found.");
         }
 
         public string GetStudyNameFromId(int studyId)
         {
-            return _studies[studyId].StudyName;
+            EnsureInitialized();
+
+            if (!_studies.TryGetValue(studyId, out Study.Study study))
+            {
+                throw new KeyNotFoundException($"Study with ID '{studyId}' not found.");
+            }
+
+            return study.StudyName;
         }
 
         public Dictionary<string, object> GetStudySystemAttrs(int studyId)
         {
-            return _studies[studyId].SystemAttrs;
+            EnsureInitialized();
+
+            if (!_studies.TryGetValue(studyId, out Study.Study study))
+            {
+                throw new KeyNotFoundException($"Study with ID '{studyId}' not found.");
+            }
+
+            return study.SystemAttrs;
         }
 
         public Dictionary<string, object> GetStudyUserAttrs(int studyId)
         {
-            return _studies[studyId].UserAttrs;
+            EnsureInitialized();
+
+            if (!_studies.TryGetValue(studyId, out Study.Study study))
+            {
+                throw new KeyNotFoundException($"Study with ID '{studyId}' not found.");
+            }
+
+            return study.UserAttrs;
         }
 
         public Trial.Trial GetTrial(int trialId)
         {
+            EnsureInitialized();
+
+            if (_trialCache.TryGetValue(trialId, out Trial.Trial trial))
+            {
+                return trial;
+            }
+
             return _studies.Values.First(s => s.Trials.Any(t => t.TrialId == trialId))
                            .Trials.First(t => t.TrialId == trialId);
         }
 
         public int GetTrialIdFromStudyIdTrialNumber(int studyId, int trialNumber)
         {
-            return _studies[studyId].Trials.Find(t => t.Number == trialNumber).TrialId;
+            EnsureInitialized();
+
+            if (!_studies.TryGetValue(studyId, out Study.Study study))
+            {
+                throw new KeyNotFoundException($"Study with ID '{studyId}' not found.");
+            }
+
+            Trial.Trial trial = study.Trials.FirstOrDefault(t => t.Number == trialNumber);
+            if (trial == null)
+            {
+                throw new KeyNotFoundException($"Trial with number '{trialNumber}' not found in study '{studyId}'.");
+            }
+            return trial.TrialId;
         }
 
         public int GetTrialNumberFromId(int trialId)
         {
-            return GetTrial(trialId).Number;
+            EnsureInitialized();
+
+            if (!_trialCache.TryGetValue(trialId, out Trial.Trial trial))
+            {
+                throw new KeyNotFoundException($"Trial with ID '{trialId}' not found.");
+            }
+
+            return trial.Number;
         }
 
         public double GetTrialParam(int trialId, string paramName)
         {
-            return (double)GetTrial(trialId).Params[paramName];
+            EnsureInitialized();
+
+            if (!_trialCache.TryGetValue(trialId, out Trial.Trial trial))
+            {
+                throw new KeyNotFoundException($"Trial with ID {trialId} not found.");
+            }
+
+            if (!trial.Params.TryGetValue(paramName, out object paramValue))
+            {
+                throw new KeyNotFoundException($"Parameter '{paramName}' not found in trial {trialId}.");
+            }
+
+            return (double)paramValue;
         }
 
         public Dictionary<string, object> GetTrialParams(int trialId)
         {
-            return GetTrial(trialId).Params.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+            EnsureInitialized();
+
+            if (!_trialCache.TryGetValue(trialId, out Trial.Trial trial))
+            {
+                throw new KeyNotFoundException($"Trial with ID {trialId} not found.");
+            }
+
+            return trial.Params.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
         }
 
         public Dictionary<string, object> GetTrialSystemAttrs(int trialId)
         {
-            return GetTrial(trialId).SystemAttrs.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+            EnsureInitialized();
+
+            if (!_trialCache.TryGetValue(trialId, out Trial.Trial trial))
+            {
+                throw new KeyNotFoundException($"Trial with ID {trialId} not found.");
+            }
+
+            return trial.SystemAttrs.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
         }
 
         public Dictionary<string, object> GetTrialUserAttrs(int trialId)
         {
-            return GetTrial(trialId).UserAttrs.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+            EnsureInitialized();
+
+            if (!_trialCache.TryGetValue(trialId, out Trial.Trial trial))
+            {
+                throw new KeyNotFoundException($"Trial with ID {trialId} not found.");
+            }
+
+            return trial.UserAttrs.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
         }
 
         public void RemoveSession()
@@ -353,17 +560,38 @@ namespace Optuna.Storage.Journal
 
         public void SetStudySystemAttr(int studyId, string key, object value)
         {
-            _studies[studyId].SystemAttrs[key] = value;
+            EnsureInitialized();
+
+            if (!_studies.TryGetValue(studyId, out Study.Study study))
+            {
+                throw new KeyNotFoundException($"Study with ID '{studyId}' not found.");
+            }
+
+            study.SystemAttrs[key] = value;
         }
 
         public void SetStudyUserAttr(int studyId, string key, object value)
         {
-            _studies[studyId].UserAttrs[key] = value;
+            EnsureInitialized();
+
+            if (!_studies.TryGetValue(studyId, out Study.Study study))
+            {
+                throw new KeyNotFoundException($"Study with ID '{studyId}' not found.");
+            }
+
+            study.UserAttrs[key] = value;
         }
 
         public void SetTrailParam(int trialId, string paramName, double paramValueInternal, object distribution)
         {
-            GetTrial(trialId).Params[paramName] = paramValueInternal;
+            EnsureInitialized();
+
+            if (!_trialCache.TryGetValue(trialId, out Trial.Trial trial))
+            {
+                throw new KeyNotFoundException($"Trial with ID {trialId} not found.");
+            }
+
+            trial.Params[paramName] = paramValueInternal;
         }
 
         public void SetTrialIntermediateValue(int trialId, int intermediateStep, double intermediateValue)
@@ -373,20 +601,44 @@ namespace Optuna.Storage.Journal
 
         public bool SetTrialStateValue(int trialId, TrialState state, double[] values = null)
         {
-            Trial.Trial trial = GetTrial(trialId);
+            EnsureInitialized();
+
+            if (!_trialCache.TryGetValue(trialId, out Trial.Trial trial))
+            {
+                throw new KeyNotFoundException($"Trial with ID {trialId} not found.");
+            }
+
             trial.State = state;
-            trial.Values = values;
+            if (values != null)
+            {
+                trial.Values = values;
+            }
+
             return true;
         }
 
         public void SetTrialSystemAttr(int trialId, string key, object value)
         {
-            GetTrial(trialId).SystemAttrs[key] = value;
+            EnsureInitialized();
+
+            if (!_trialCache.TryGetValue(trialId, out Trial.Trial trial))
+            {
+                throw new KeyNotFoundException($"Trial with ID {trialId} not found.");
+            }
+
+            trial.SystemAttrs[key] = value;
         }
 
         public void SetTrialUserAttr(int trialId, string key, object value)
         {
-            GetTrial(trialId).UserAttrs[key] = value;
+            EnsureInitialized();
+
+            if (!_trialCache.TryGetValue(trialId, out Trial.Trial trial))
+            {
+                throw new KeyNotFoundException($"Trial with ID {trialId} not found.");
+            }
+
+            trial.UserAttrs[key] = value;
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Reference Issues/PRs

<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->

- Improve result log file load speed.
  - Tunny was loading the result file when launching the UI, and when the log file was large, it took a long time to launch.
  - With this update, log files are now about 60 times faster to load.
    - What used to take about 5 minutes to load the results of 30,000 trials can now be loaded in about 5 seconds.